### PR TITLE
Fixes spacing issue in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ debug:
 	cmake --build ./build --config Debug --target all -j 10
 
 all:
-    make clear
-    make protocols
+	make clear
+	make protocols
 	make release


### PR DESCRIPTION
Believe makefile requires tabs over spaces, fixes the error "Makefile:48: *** missing separator.  Stop." when trying to run make command