### PR TITLE
fix: fix issue with util-linux rename on nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,7 +13,7 @@
   libthai,
   pango,
   pcre,
-  utillinux,
+  utillinux ? util-linux,
   wayland,
   wayland-protocols,
   wayland-scanner,

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,7 +13,7 @@
   libthai,
   pango,
   pcre,
-  utillinux ? util-linux,
+  util-linux,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     wayland-protocols
     wayland-scanner
     libXdmcp
-    utillinux
+    util-linux
   ];
 
   configurePhase = ''


### PR DESCRIPTION
nix has recently renamed `utillinux` to `util-linux`, so the scripted needed to be updated for this