### PR TITLE
feat: Provide way to override default config file path

### DIFF
--- a/src/Hyprpaper.hpp
+++ b/src/Hyprpaper.hpp
@@ -34,6 +34,7 @@ public:
     std::vector<std::unique_ptr<SMonitor>> m_vMonitors;
 
     bool        m_bIPCEnabled = true;
+    std::string explicitConfigPath;
 
     void        removeOldHyprpaperImages();
     void        preloadAllWallpapersFromConfig();

--- a/src/Hyprpaper.hpp
+++ b/src/Hyprpaper.hpp
@@ -34,7 +34,7 @@ public:
     std::vector<std::unique_ptr<SMonitor>> m_vMonitors;
 
     bool        m_bIPCEnabled = true;
-    std::string explicitConfigPath;
+    std::string m_szExplicitConfigPath;
 
     void        removeOldHyprpaperImages();
     void        preloadAllWallpapersFromConfig();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -4,17 +4,17 @@
 CConfigManager::CConfigManager() {
     // init the entire thing
 
-    std::string CONFIGPATH;
-    if (g_pHyprpaper->explicitConfigPath == "") {
+    std::string configPath;
+    if (g_pHyprpaper->m_szExplicitConfigPath == "") {
         const char *const ENVHOME = getenv("HOME");
-        CONFIGPATH = ENVHOME + (std::string) "/.config/hypr/hyprpaper.conf";
+        configPath = ENVHOME + (std::string) "/.config/hypr/hyprpaper.conf";
     }
     else {
-        CONFIGPATH = g_pHyprpaper->explicitConfigPath;
+        configPath = g_pHyprpaper->m_szExplicitConfigPath;
     }
 
     std::ifstream ifs;
-    ifs.open(CONFIGPATH);
+    ifs.open(configPath);
 
     if (!ifs.good()) {
         Debug::log(CRIT, "Hyprpaper was not provided a config!");

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -4,8 +4,14 @@
 CConfigManager::CConfigManager() {
     // init the entire thing
 
-    const char* const ENVHOME = getenv("HOME");
-    const std::string CONFIGPATH = ENVHOME + (std::string) "/.config/hypr/hyprpaper.conf";
+    std::string CONFIGPATH;
+    if (g_pHyprpaper->explicitConfigPath == "") {
+        const char *const ENVHOME = getenv("HOME");
+        CONFIGPATH = ENVHOME + (std::string) "/.config/hypr/hyprpaper.conf";
+    }
+    else {
+        CONFIGPATH = g_pHyprpaper->explicitConfigPath;
+    }
 
     std::ifstream ifs;
     ifs.open(CONFIGPATH);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,23 @@
 int main(int argc, char** argv, char** envp) {
     Debug::log(LOG, "Welcome to hyprpaper!\nbuilt from commit %s (%s)", GIT_COMMIT_HASH, GIT_COMMIT_MESSAGE);
 
+    // parse some args
+    std::string configPath;
+    for (int i = 1; i < argc; ++i) {
+        if ((!strcmp(argv[i], "-c") || !strcmp(argv[i], "--config")) && argc >= i + 2) {
+            configPath = std::string(argv[++i]);
+            Debug::log(LOG, "Using config location %s.", configPath.c_str());
+        } else {
+            std::cout << "Hyprpaper usage: hyprpaper [arg [...]].\n\nArguments:\n" <<
+                "--help         -h | Show this help message\n" <<
+                "--config       -c | Specify config file to use\n";
+            return 1;
+        }
+    }
+
     // starts
     g_pHyprpaper = std::make_unique<CHyprpaper>();
+    g_pHyprpaper->explicitConfigPath = configPath;
     g_pHyprpaper->init();
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv, char** envp) {
 
     // starts
     g_pHyprpaper = std::make_unique<CHyprpaper>();
-    g_pHyprpaper->explicitConfigPath = configPath;
+    g_pHyprpaper->m_szExplicitConfigPath = configPath;
     g_pHyprpaper->init();
 
     return 0;


### PR DESCRIPTION
Provides config file path overriding in same fashion hyprland currently does (through `--config|-c`).
Should be consistent with hyprland codebase's implementation. Tested.