### PR TITLE
Allow parsing home dir with contains keyword

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -122,14 +122,14 @@ void CConfigManager::handleWallpaper(const std::string& COMMAND, const std::stri
 
     bool contain = false;
 
-    if (WALLPAPER[0] == '~') {
-        static const char* const ENVHOME = getenv("HOME");
-        WALLPAPER = std::string(ENVHOME) + WALLPAPER.substr(1);
-    }
-
     if (WALLPAPER.find("contain:") == 0) {
         WALLPAPER = WALLPAPER.substr(8);
         contain = true;
+    }
+
+    if (WALLPAPER[0] == '~') {
+        static const char* const ENVHOME = getenv("HOME");
+        WALLPAPER = std::string(ENVHOME) + WALLPAPER.substr(1);
     }
 
     if (!std::filesystem::exists(WALLPAPER)) {


### PR DESCRIPTION
Problem if config had:
`wallpaper = DP-1,contain:~/Pictures/bg.jpg`

Config was not parsing '~' to the HOME directory.

Fixed by changing the order of parsing out the 'contain:' keyword out before parsing path for bg.