### PR TITLE
Update ConfigManager.cpp

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -21,7 +21,7 @@ CConfigManager::CConfigManager() {
         if (g_pHyprpaper->m_szExplicitConfigPath.empty()) {
             Debug::log(CRIT, "No config file provided. Default config file `~/.config/hypr/hyprpaper.conf` couldn't be opened.");
         } else {
-            Debug::log(CRIT, "No config file provided. Specified file `%s` couldn't be opened.", configPath);
+            Debug::log(CRIT, "No config file provided. Specified file `%s` couldn't be opened.", configPath.c_str());
         }
         exit(1);
     }


### PR DESCRIPTION
```
/ix/build/0PFdEv3b1DNZ4As2/src/src/config/ConfigManager.cpp:24:98: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
            Debug::log(CRIT, "No config file provided. Specified file %s couldn't be opened.", configPath);
                                                                                                 ^
1 error generated.
```