### PR TITLE
Update Hyprpaper.cpp, fix clang++ build

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -199,7 +199,7 @@ void CHyprpaper::ensurePoolBuffersPresent() {
             if (m->size == Vector2D())
                 continue;
 
-            auto it = std::find_if(m_vBuffers.begin(), m_vBuffers.end(), [&](const std::unique_ptr<SPoolBuffer>& el) {
+            auto it = std::find_if(m_vBuffers.begin(), m_vBuffers.end(), [wt = wt, &m](const std::unique_ptr<SPoolBuffer>& el) {
                 return el->target == wt.m_szPath && el->pixelSize == m->size * m->scale;
             });
 


### PR DESCRIPTION
```
/ix/build/t0VbWw3Gs81M6qL1/src/src/Hyprpaper.cpp:203:38: error: reference to local binding 'wt' declared in enclosing function 'CHyprpaper::ensurePoolBuffersPresent'
                return el->target == wt.m_szPath && el->pixelSize == m->size * m->scale;
                                     ^
/ix/build/t0VbWw3Gs81M6qL1/src/src/Hyprpaper.cpp:196:23: note: 'wt' declared here
    for (auto& [file, wt] : m_mWallpaperTargets) {
```