### PR TITLE
Fix clang build, second version

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -200,7 +200,7 @@ void CHyprpaper::ensurePoolBuffersPresent() {
                 continue;
 
             auto it = std::find_if(m_vBuffers.begin(), m_vBuffers.end(), [wt = &wt, &m](const std::unique_ptr<SPoolBuffer>& el) {
-                return el->target == wt.m_szPath && el->pixelSize == m->size * m->scale;
+                return el->target == wt->m_szPath && el->pixelSize == m->size * m->scale;
             });
 
             if (it == m_vBuffers.end()) {

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -199,7 +199,7 @@ void CHyprpaper::ensurePoolBuffersPresent() {
             if (m->size == Vector2D())
                 continue;
 
-            auto it = std::find_if(m_vBuffers.begin(), m_vBuffers.end(), [&](const std::unique_ptr<SPoolBuffer>& el) {
+            auto it = std::find_if(m_vBuffers.begin(), m_vBuffers.end(), [wt = &wt, &m](const std::unique_ptr<SPoolBuffer>& el) {
                 return el->target == wt.m_szPath && el->pixelSize == m->size * m->scale;
             });
 


### PR DESCRIPTION
Capture wt by reference, thus fixing https://github.com/hyprwm/hyprpaper/pull/31#issuecomment-1372228788

I can not reproduce asserts from linked PR, but I think that now I fully reproduce [&] behaviour.

```
/ix/build/t0VbWw3Gs81M6qL1/src/src/Hyprpaper.cpp:203:38: error: reference to local binding 'wt' declared in enclosing function 'CHyprpaper::ensurePoolBuffersPresent'
                return el->target == wt.m_szPath && el->pixelSize == m->size * m->scale;
                                     ^
/ix/build/t0VbWw3Gs81M6qL1/src/src/Hyprpaper.cpp:196:23: note: 'wt' declared here
    for (auto& [file, wt] : m_mWallpaperTargets) {
```