### PR TITLE
Allows using wallpaper files without extensions

### DIFF
--- a/src/render/WallpaperTarget.cpp
+++ b/src/render/WallpaperTarget.cpp
@@ -10,10 +10,18 @@ void CWallpaperTarget::create(const std::string& path) {
     const auto BEGINLOAD = std::chrono::system_clock::now();
 
     cairo_surface_t* CAIROSURFACE = nullptr;
-    const auto len = path.length();
-    if (path.find(".png") == len - 4 || path.find(".PNG") == len - 4) {
+    const auto len = path.len()+36;
+    char cmd[len];
+    snprintf(cmd, len, "file -b --mime-type %s", path.c_str());
+    FILE *file = popen(cmd, "r");
+    char file_type[16];
+    fread(file_type, 1, 15, file);
+    file_type[15]='\0';
+    pclose(file);
+    Debug::log(LOG, "File: %s", file_type);
+    if (strncmp(file_type, "image/png", 9) == 0) { // file_type may have new line and EOF at the end
         CAIROSURFACE = cairo_image_surface_create_from_png(path.c_str());
-    } else if (path.find(".jpg") == len - 4 || path.find(".JPG") == len - 4 || path.find(".jpeg") == len - 5 || path.find(".JPEG") == len - 5) {
+    } else if (strncmp(file_type, "image/jpeg", 10) == 0) {
         CAIROSURFACE = JPEG::createSurfaceFromJPEG(path);
         m_bHasAlpha = false;
     } else {

--- a/src/render/WallpaperTarget.hpp
+++ b/src/render/WallpaperTarget.hpp
@@ -2,6 +2,8 @@
 
 #include "../defines.hpp"
 #include "../helpers/Jpeg.hpp"
+#include <stdio.h>
+#include <string.h>
 
 class CWallpaperTarget {
 public:


### PR DESCRIPTION
This resolves #52, though it introduces a dependency on the file executable. That shouldn't be a problem though, as on Arch file is required by the base package.