### PR TITLE
Fix compilation with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ execute_process(
 #
 
 include_directories(.)
-add_compile_options(-std=c++23 -DWLR_USE_UNSTABLE )
+add_compile_options(-std=c++2b -DWLR_USE_UNSTABLE )
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing)
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
Using `-std=c++2b` instead of `-std=c++23` allows compilation with clang instead of gcc.
(This also works with gcc of course)