### PR TITLE
[RFC] Filetype detection without extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(hyprpaper
         OpenGL
         GLESv2
         pthread
+        magic
         ${CMAKE_THREAD_LIBS_INIT}
         ${CMAKE_SOURCE_DIR}/wlr-layer-shell-unstable-v1-protocol.o
         ${CMAKE_SOURCE_DIR}/xdg-shell-protocol.o

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@
   cmake,
   ninja,
   cairo,
+  file,
   fribidi,
   libdatrie,
   libjpeg,
@@ -34,6 +35,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     cairo
+    file
     fribidi
     libdatrie
     libjpeg

--- a/src/render/WallpaperTarget.cpp
+++ b/src/render/WallpaperTarget.cpp
@@ -26,8 +26,7 @@ void CWallpaperTarget::create(const std::string& path) {
         const auto first_word = type_str.substr(0, type_str.find(" "));
         if (first_word == "PNG") {
             CAIROSURFACE = cairo_image_surface_create_from_png(path.c_str());
-        }
-        else if (first_word == "JPEG") {
+        } else if (first_word == "JPEG") {
             CAIROSURFACE = JPEG::createSurfaceFromJPEG(path);
             m_bHasAlpha = false;
         }

--- a/src/render/WallpaperTarget.cpp
+++ b/src/render/WallpaperTarget.cpp
@@ -22,15 +22,16 @@ void CWallpaperTarget::create(const std::string& path) {
         // magic is slow, so only use it when no recognized extension is found
         auto handle = magic_open(MAGIC_NONE|MAGIC_COMPRESS);
         magic_load(handle, nullptr);
+
         const auto type_str = std::string(magic_file(handle, path.c_str()));
         const auto first_word = type_str.substr(0, type_str.find(" "));
+
         if (first_word == "PNG") {
             CAIROSURFACE = cairo_image_surface_create_from_png(path.c_str());
         } else if (first_word == "JPEG") {
             CAIROSURFACE = JPEG::createSurfaceFromJPEG(path);
             m_bHasAlpha = false;
-        }
-        else {
+        } else {
             Debug::log(CRIT, "unrecognized image %s", path.c_str());
             exit(1);
         }

--- a/src/render/WallpaperTarget.cpp
+++ b/src/render/WallpaperTarget.cpp
@@ -1,5 +1,7 @@
 #include "WallpaperTarget.hpp"
 
+#include <magic.h>
+
 CWallpaperTarget::~CWallpaperTarget() {
     cairo_surface_destroy(m_pCairoSurface);
 }
@@ -17,8 +19,22 @@ void CWallpaperTarget::create(const std::string& path) {
         CAIROSURFACE = JPEG::createSurfaceFromJPEG(path);
         m_bHasAlpha = false;
     } else {
-        Debug::log(CRIT, "unrecognized image %s", path.c_str());
-        exit(1);
+        // magic is slow, so only use it when no recognized extension is found
+        auto handle = magic_open(MAGIC_NONE|MAGIC_COMPRESS);
+        magic_load(handle, nullptr);
+        const auto type_str = std::string(magic_file(handle, path.c_str()));
+        const auto first_word = type_str.substr(0, type_str.find(" "));
+        if (first_word == "PNG") {
+            CAIROSURFACE = cairo_image_surface_create_from_png(path.c_str());
+        }
+        else if (first_word == "JPEG") {
+            CAIROSURFACE = JPEG::createSurfaceFromJPEG(path);
+            m_bHasAlpha = false;
+        }
+        else {
+            Debug::log(CRIT, "unrecognized image %s", path.c_str());
+            exit(1);
+        }
     }
 
     if (cairo_surface_status(CAIROSURFACE) != CAIRO_STATUS_SUCCESS) {


### PR DESCRIPTION
Related to: #52 #55

I did my best to implement filetype detection using libmagic. This should be available in most distributions.

TODO:

- [x] Nix package fixes (I cannot test myself. You most likely need `file-devel`, `file-magic`, or `libmagic` to output `-lmagic` from `pkg-config`.)