### PR TITLE
Reset hasATarget when issuing wallpaper command

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -270,6 +270,8 @@ void CHyprpaper::clearWallpaperFromMonitor(const std::string& monname) {
     if (it != m_mMonitorActiveWallpaperTargets.end())
         m_mMonitorActiveWallpaperTargets.erase(it);
 
+    PMONITOR->hasATarget = true;
+
     if (PMONITOR->pCurrentLayerSurface) {
 
         PMONITOR->pCurrentLayerSurface = nullptr;


### PR DESCRIPTION
Fixes issue #74

The `clearWallpaperFromMonitor` function clears most properties of the `SMonitor` struct to prepare for reloading its wallpaper. However, if no initial wallpaper was loaded by the config file the `hasATarget` flag would be stuck to false, blocking IPC commands from updating its wallpaper.

This fixes the issue by setting the flag back to its default value in `clearWallpaperFromMonitor`.