### PR TITLE
fix: Read absolute path of symlinks

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -123,7 +123,9 @@ void CHyprpaper::preloadAllWallpapersFromConfig() {
         m_mWallpaperTargets[wp] = CWallpaperTarget();
         if (std::filesystem::is_symlink(wp)) {
             auto real_wp = std::filesystem::read_symlink(wp);
-            m_mWallpaperTargets[wp].create(real_wp);
+            std::filesystem::path absolute_path = std::filesystem::path(wp).parent_path() / real_wp;
+            absolute_path = absolute_path.lexically_normal();
+            m_mWallpaperTargets[wp].create(absolute_path);
         } else {
             m_mWallpaperTargets[wp].create(wp);
         }


### PR DESCRIPTION
Currently, hyprpaper assumes absolute paths in symlinks. This converts the symlink target to its absolute path before loading.