### PR TITLE
Always draw a black background behind the wallpaper

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -481,41 +481,24 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
     cairo_paint(PCAIRO);
     cairo_restore(PCAIRO);
 
-    if (CONTAIN) {
-        cairo_set_source_rgb(PCAIRO, 0, 0, 0);
-        cairo_rectangle(PCAIRO, 0, 0, DIMENSIONS.x, DIMENSIONS.y);
-
-        cairo_fill(PCAIRO);
-
-        cairo_surface_flush(PBUFFER->surface);
-    }
+    // always draw a black background behind the wallpaper
+    cairo_set_source_rgb(PCAIRO, 0, 0, 0);
+    cairo_rectangle(PCAIRO, 0, 0, DIMENSIONS.x, DIMENSIONS.y);
+    cairo_fill(PCAIRO);
+    cairo_surface_flush(PBUFFER->surface);
 
     // get scale
     // we always do cover
-    float scale;
+    double scale;
     Vector2D origin;
 
-    if (!CONTAIN) {
-        if (pMonitor->size.x / pMonitor->size.y > PWALLPAPERTARGET->m_vSize.x / PWALLPAPERTARGET->m_vSize.y) {
-            scale = DIMENSIONS.x / PWALLPAPERTARGET->m_vSize.x;
-
-            origin.y = -(PWALLPAPERTARGET->m_vSize.y * scale - DIMENSIONS.y) / 2.f / scale;
-
-        } else {
-            scale = DIMENSIONS.y / PWALLPAPERTARGET->m_vSize.y;
-
-            origin.x = -(PWALLPAPERTARGET->m_vSize.x * scale - DIMENSIONS.x) / 2.f / scale;
-        }
+    const bool LOWASPECTRATIO = pMonitor->size.x / pMonitor->size.y > PWALLPAPERTARGET->m_vSize.x / PWALLPAPERTARGET->m_vSize.y;
+    if ((CONTAIN && !LOWASPECTRATIO) || (!CONTAIN && LOWASPECTRATIO)) {
+        scale = DIMENSIONS.x / PWALLPAPERTARGET->m_vSize.x;
+        origin.y = -(PWALLPAPERTARGET->m_vSize.y * scale - DIMENSIONS.y) / 2.0 / scale;
     } else {
-        if (pMonitor->size.x / pMonitor->size.y > PWALLPAPERTARGET->m_vSize.x / PWALLPAPERTARGET->m_vSize.y) {
-            scale = (DIMENSIONS.y) / PWALLPAPERTARGET->m_vSize.y;
-
-            origin.x = (DIMENSIONS.x - PWALLPAPERTARGET->m_vSize.x * scale) / 2.0 / scale;
-        } else {
-            scale = (DIMENSIONS.x) / PWALLPAPERTARGET->m_vSize.x;
-
-            origin.y = (DIMENSIONS.y - PWALLPAPERTARGET->m_vSize.y * scale) / 2.0 / scale;
-        }
+        scale = DIMENSIONS.y / PWALLPAPERTARGET->m_vSize.y;
+        origin.x = -(PWALLPAPERTARGET->m_vSize.x * scale - DIMENSIONS.x) / 2.0 / scale;
     }
 
     Debug::log(LOG, "Image data for %s: %s at [%.2f, %.2f], scale: %.2f (original image size: [%i, %i])", pMonitor->name.c_str(), PWALLPAPERTARGET->m_szPath.c_str(), origin.x, origin.y, scale, (int)PWALLPAPERTARGET->m_vSize.x, (int)PWALLPAPERTARGET->m_vSize.y);


### PR DESCRIPTION
It's related to:
https://github.com/hyprwm/Hyprland/issues/3523

I moved ``scale`` to a double because from what I've seen it sometimes prevented single lines of pixels poking from behind but just that isn't enough to completely resolve the issue. Only sensible way I found was to just draw a black background first and then draw the wallpaper.

Also rearranged the if statement a little to reduce code repetition.