### PR TITLE
Fix nix build, update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683014792,
-        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
-        "owner": "NixOS",
+        "lastModified": 1702645756,
+        "narHash": "sha256-qKI6OR3TYJYQB3Q8mAZ+DG4o/BR9ptcv9UnRV2hzljc=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
+        "rev": "40c3c94c241286dd2243ea34d3aef8a488f9e4d0",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,6 +8,7 @@
   file,
   fribidi,
   libdatrie,
+  libGL,
   libjpeg,
   libselinux,
   libsepol,
@@ -38,6 +39,7 @@ stdenv.mkDerivation {
     file
     fribidi
     libdatrie
+    libGL
     libjpeg
     libselinux
     libsepol


### PR DESCRIPTION
At the moment, the hyprpaper build is failing with the following error:
```
In file included from /build/x9p86pbqbvwry48qacajgfyk8zd2sxir-source/src/render/../defines.hpp:3,
                 from /build/x9p86pbqbvwry48qacajgfyk8zd2sxir-source/src/render/LayerSurface.hpp:3,
                 from /build/x9p86pbqbvwry48qacajgfyk8zd2sxir-source/src/render/LayerSurface.cpp:1:
/build/x9p86pbqbvwry48qacajgfyk8zd2sxir-source/src/render/../includes.hpp:30:10: fatal error: GLES3/gl32.h: No such file or directory
   30 | #include <GLES3/gl32.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```
Fixed the problem by adding libGL to buildInputs. Also updated flake.lock to the latest nixos-23.11.