### PR TITLE
Recursive symlink preload support

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -129,14 +129,13 @@ void CHyprpaper::preloadAllWallpapersFromConfig() {
             continue;
 
         m_mWallpaperTargets[wp] = CWallpaperTarget();
-        if (std::filesystem::is_symlink(wp)) {
-            auto real_wp = std::filesystem::read_symlink(wp);
-            std::filesystem::path absolute_path = std::filesystem::path(wp).parent_path() / real_wp;
-            absolute_path = absolute_path.lexically_normal();
-            m_mWallpaperTargets[wp].create(absolute_path);
-        } else {
-            m_mWallpaperTargets[wp].create(wp);
+        std::filesystem::path create_wp = wp;
+        while (std::filesystem::is_symlink(create_wp)) {
+            auto real_wp = std::filesystem::read_symlink(create_wp);
+            std::filesystem::path absolute_path = std::filesystem::path(create_wp).parent_path() / real_wp;
+            create_wp = absolute_path.lexically_normal();
         }
+        m_mWallpaperTargets[wp].create(create_wp);
     }
 
     g_pConfigManager->m_dRequestedPreloads.clear();


### PR DESCRIPTION
Hi. I stumbled upon this pretty nice software, but immediately encountered a problem: hyprpaper can preload only a path to file or path to a symlink that gets dereferenced once. Symlinks to symlinks do not work - well, not anymore :)