### PR TITLE
Fix error checking while changing wallpaper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ splash = true
 
 ```
 
-Preload will tell Hyprland to load a particular image (supported formats: png, jpg, jpeg, webp). Wallpaper will apply the wallpaper to the selected output (`monitor` is the monitor's name, easily can be retrieved with `hyprctl monitors`. You can leave it empty for a wildcard (aka fallback). You can also use `desc:` followed by the monitor's description without the (PORT) at the end)
+Preload will tell Hyprland to load a particular image (supported formats: png, jpg, jpeg, webp). Wallpaper will apply the wallpaper to the selected output (`monitor` is the monitor's name, easily can be retrieved with `hyprctl monitors`. You can leave it empty to set all monitors without an active wallpaper. You can also use `desc:` followed by the monitor's description without the (PORT) at the end)
 
 You may add `contain:` before the file path in `wallpaper=` to set the mode to contain instead of cover:
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -36,24 +36,29 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
         return result;
     }
 
-    g_pHyprpaper->clearWallpaperFromMonitor(MONITOR);
-    g_pHyprpaper->m_mMonitorActiveWallpapers[MONITOR] = WALLPAPER;
-    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].contain = contain;
-
-    if (MONITOR.empty()) {
+    if (MONITOR.empty()) { //if the monitor string is empty we set all the empty monitors to the same wallpaper
         for (auto& m : g_pHyprpaper->m_vMonitors) {
             if (!m->hasATarget || m->wildcard) {
+                Debug::log(LOG, "Setting wallpaper for monitor %s", m->name);
                 g_pHyprpaper->clearWallpaperFromMonitor(m->name);
                 g_pHyprpaper->m_mMonitorActiveWallpapers[m->name] = WALLPAPER;
                 g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].contain = contain;
             }
         }
-    } else {
-        const auto PMON = g_pHyprpaper->getMonitorFromName(MONITOR);
-        if (PMON)
-            PMON->wildcard = false;
+        return result;
     }
 
+    const auto PMON = g_pHyprpaper->getMonitorFromName(MONITOR);
+    if (!PMON){ //does monitor by name of MONITOR exist?
+        result.setError("wallpaper failed (no such monitor)");
+        return result;
+    }
+
+    g_pHyprpaper->clearWallpaperFromMonitor(MONITOR); //should be fine to keep using MONITOR instead of using PMON->name here
+    g_pHyprpaper->m_mMonitorActiveWallpapers[MONITOR] = WALLPAPER;
+    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].contain = contain;
+
+    PMON->wildcard = false;
     return result;
 }
 


### PR DESCRIPTION
In response to #138
Fixes being able to assign a wallpaper to a nonexistent monitor by throwing an error if the monitor doesn't exist.
Clarified README to the specifics of the handleWallpaper function.

Without really modifying the existing logic for the `if (MONITOR.empty()) {` part there isn't a neat way of just assigning a wallpaper to all screens at once.

This does fix the issue aswell as follows:
```sh
$ hyprctl hyprpaper listactive
eDP-1 = <wp1>
HDMI-A-1 = <wp2>

 $ hyprctl hyprpaper preload <wp3>
ok

$ hyprctl hyprpaper wallpaper ", <wp3>"
ok
$ hyprctl hyprpaper listactive
eDP-1 = <wp1>
HDMI-A-1 = <wp2>

$ hyprctl hyprpaper wallpaper "ramd, <wp3>"
wallpaper failed (no such monitor)
$ hyprctl hyprpaper listactive
eDP-1 = <wp1>
HDMI-A-1 = <wp2>
```