### PR TITLE
Updated link to reflect arch package movement from community to extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hyprpaper is a blazing fast wallpaper utility for Hyprland with the ability to d
 
 # Installation
 
-[Arch Linux](https://archlinux.org/packages/community/x86_64/hyprpaper/): `pacman -S hyprpaper`
+[Arch Linux](https://archlinux.org/packages/extra/x86_64/hyprpaper/): `pacman -S hyprpaper`
 
 ## Manual:
 


### PR DESCRIPTION
A small edit to the readme that links the user to the proper page for the arch package. The old link was outdated as the package has been moved from the community repo to the extra repo.