### PR TITLE
Set standard exclusively for c++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ function(protocol protoPath protoName external)
 endfunction()
 
 include_directories(.)
-add_compile_options(-std=c++2b -DWLR_USE_UNSTABLE )
+set(CMAKE_CXX_STANDARD 23)
+add_compile_options(-DWLR_USE_UNSTABLE)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing)
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
Using `add_compile_options(-std=c++2b)` passes the flag to C compiler aswell. gcc ignores it but clang fails compilation with the error: `invalid argument '-std=c++2b' not allowed with 'C'`.

Using `set(CMAKE_CXX_STANDARD 23)` fixes that.