### PR TITLE
Added missing hyprlang-devel dependency for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and might not be packaged for your distro yet. If that's the case, build and ins
 
 To install all of these in Fedora, run this command:
 ```
-sudo dnf install wayland-devel wayland-protocols-devel pango-devel cairo-devel file-devel libglvnd-devel libglvnd-core-devel libjpeg-turbo-devel libwebp-devel gcc-c++
+sudo dnf install wayland-devel wayland-protocols-devel hyprlang-devel pango-devel cairo-devel file-devel libglvnd-devel libglvnd-core-devel libjpeg-turbo-devel libwebp-devel gcc-c++
 ```
 
 On Arch:


### PR DESCRIPTION
As commented in #161, the `hyprlang-devel` package was missing in the Fedora instructions.
After installing the dependency it compiles and installs without any errors