### PR TITLE
Remove comma from monitor description

### DIFF
--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -35,8 +35,11 @@ void Events::name(void* data, wl_output* wl_output, const char* name) {
 
 void Events::description(void* data, wl_output* wl_output, const char* description) {
     const auto PMONITOR = (SMonitor*)data;
+    // remove comma character from description. This allow monitor specific rules to work on monitor with comma on their description
+    std::string m_description = description;
+    std::erase(m_description, ',');
 
-    PMONITOR->description = description;
+    PMONITOR->description = m_description;
 }
 
 void Events::handleCapabilities(void* data, wl_seat* wl_seat, uint32_t capabilities) {


### PR DESCRIPTION
This change aligns the behavior of using desc to target monitors in hyprpaper with that in [hyprland](https://github.com/hyprwm/Hyprland/blob/b1a94302897ae559c877471f7d365651bcd24ad4/src/helpers/Monitor.cpp#L58).