### PR TITLE
Fix typo in hm-module.nix

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -20,7 +20,7 @@ in {
     enable = mkEnableOption "Hyprpaper, Hyprland's wallpaper utility";
 
     package = mkOption {
-      description = "The hyprpapr package";
+      description = "The hyprpaper package";
       type = package;
       default = self.packages.${pkgs.stdenv.hostPlatform.system}.hyprpaper;
     };


### PR DESCRIPTION
`hyprpapr` -> `hyprpaper`