### PR TITLE
Add missing splash_color config option to hm-module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -43,6 +43,12 @@ in {
       default = 2.0;
     };
 
+    splash_color = mkOption {
+      description = "Splash color";
+      type = str;
+      default = "rgba(255, 0, 0, 1.0)";
+    };
+
     preloads = mkOption {
       description = "List of paths to images that will be loaded into memory.";
       type = listOf str;
@@ -71,6 +77,7 @@ in {
       }
       splash = ${boolToString cfg.splash}
       splash_offset = ${toString cfg.splash_offset}
+      splash_color = ${cfg.splash_color}
 
       ${
         builtins.concatStringsSep "\n"

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -46,7 +46,7 @@ in {
     splash_color = mkOption {
       description = "Splash color";
       type = str;
-      default = "rgba(255, 0, 0, 1.0)";
+      default = "rgba(85, 255, 255, 1.0)";
     };
 
     preloads = mkOption {


### PR DESCRIPTION
https://github.com/hyprwm/hyprpaper/pull/160 added a `splash_color` option which was missing in the home-manager module.