### PR TITLE
ipc: add listmonitors

### DIFF
--- a/src/ipc/Socket.cpp
+++ b/src/ipc/Socket.cpp
@@ -163,6 +163,23 @@ bool CIPCSocket::mainThreadParseRequest() {
         return true;
     }
 
+    if (copy.find("listmonitors") == 0) {
+
+        const auto numMonitors = g_pHyprpaper->m_vMonitors.size();
+        Debug::log(LOG, "numMonitors: %d", numMonitors);
+
+        m_szReply = "";
+        long unsigned int i = 0;
+        for (auto& m : g_pHyprpaper->m_vMonitors) {
+            m_szReply += m.get()->name.c_str();
+            i++;
+            if (i < numMonitors)
+                m_szReply += '\n'; // dont add newline on last entry
+        }
+
+        return true;
+    }
+
     m_szReply = "invalid command";
     return false;
 }


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

Add `listmonitors` option to the ipc. That way we will be able to query the monitors using the ipc:

```
hyprctl hyprpaper listmonitors
```

Output example:

```
DP-1
eDP-1
```

This is useful, for example I am developing a python command-line utility ([pyprpaper](https://github.com/rofe33/pyprpaper)) to automatically change wallpapers randomly. I am switching to use  the `socket` module instead of `hyprctl` (to not depend on `Hyprland` and let other compositors use the script). I didn't find a way to get the monitors, and I don't want to depend on other python packages. I read the code of `hyprpaper` and saw that it is already built-in, so I added the feature.

Thank you :)

### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I will make also a pull request that adds `listmonitors` in the hyprpaper's help page.

### Is it ready for merging, or does it need work?

Yes, it is ready.