### PR TITLE
Fix `desc:` wallpaper priority

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -367,15 +367,17 @@ void CHyprpaper::ensureMonitorHasActiveWallpaper(SMonitor* pMonitor) {
         }
     }
 
-    for (auto& [mon, path1] : m_mMonitorActiveWallpapers) {
-        if (mon == pMonitor->name) {
-            for (auto& [path2, target] : m_mWallpaperTargets) {
-                if (path1 == path2) {
-                    it->second = &target;
-                    break;
+    if (!it->second) {
+        for (auto& [mon, path1] : m_mMonitorActiveWallpapers) {
+            if (mon == pMonitor->name) {
+                for (auto& [path2, target] : m_mWallpaperTargets) {
+                    if (path1 == path2) {
+                        it->second = &target;
+                        break;
+                    }
                 }
+                break;
             }
-            break;
         }
     }
 


### PR DESCRIPTION
There was misbehaviour from config. Say, we have next config:
```
...

wallpaper = , /path/to/generic.jpg
wallpaper = DP-1, /path/to/port.jpg
wallpaper = desc:My Monitor, /path/to/desc.jpg

```

Here the `DP-1` and `desc:My Monitor` are different monitors.

_EXPECTED_: The `desc:My Monitor` renders `/path/to/desc.jpg` wallpaper
_ACTUAL_: The `desc:My Monitor` renders `/path/to/generic.jpg` wallpaper