### PR TITLE
systemd - Revert to using full path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,4 +143,4 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
 include(GNUInstallDirs)
 
 install(TARGETS hyprpaper)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION "lib/systemd/user")


### PR DESCRIPTION
Partially reverts https://github.com/hyprwm/hyprpaper/pull/208

For some reason,   with ${CMAKE_INSTALL_LIBDIR} the systemd service isn't installed if use Arch PKGBUILD, just like https://github.com/hyprwm/hypridle/pull/46. Reverting to using the full path. Sorry for the inconvenience.