### PR TITLE
Fix the installation of the systemd service file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,4 +142,4 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
 include(GNUInstallDirs)
 
 install(TARGETS hyprpaper)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION "lib/systemd/user")


### PR DESCRIPTION
When building for X64, the systemd service file ended up in /lib64, where it doesn't belong.