### PR TITLE
feat: add directory wallpaper support and deferred preloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ preload = /path/to/next_image.png
 wallpaper = monitor1,/path/to/image.png
 #if more than one monitor in use, can load a 2nd image
 wallpaper = monitor2,/path/to/next_image.png
+# you can also specify a directory path to randomly select a wallpaper from
+wallpaper = monitor3,/path/to/directory
 # .. more monitors
 
 #enable splash text rendering over the wallpaper
@@ -87,6 +89,9 @@ splash = true
 
 #fully disable ipc
 # ipc = off
+
+#enable deferred preloading (reduces memory usage but may cause slight delay when switching wallpapers)
+# defer_preload = 1
 
 
 ```

--- a/src/helpers/RandomGenerator.hpp
+++ b/src/helpers/RandomGenerator.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <random>
+
+class CRandomGenerator {
+public:
+    static CRandomGenerator& get() {
+        static CRandomGenerator instance;
+        return instance;
+    }
+
+    // Generate random index for vector size
+    size_t getRandomIndex(size_t size) {
+        if (size == 0) return 0;
+        std::uniform_int_distribution<size_t> dis(0, size - 1);
+        return dis(m_Generator);
+    }
+
+    // Get raw generator if needed
+    std::mt19937& getGenerator() {
+        return m_Generator;
+    }
+
+private:
+    CRandomGenerator() : m_Generator(m_RandomDevice()) {}
+    
+    std::random_device m_RandomDevice;
+    std::mt19937 m_Generator;
+
+    // Delete copy/move to ensure singleton
+    CRandomGenerator(const CRandomGenerator&) = delete;
+    CRandomGenerator& operator=(const CRandomGenerator&) = delete;
+    CRandomGenerator(CRandomGenerator&&) = delete;
+    CRandomGenerator& operator=(CRandomGenerator&&) = delete;
+}; 


### PR DESCRIPTION
Hi all :)
This PR adds two new features:

1. Directory Wallpaper Support
- Users can now specify a directory path in the wallpaper config
- Hyprpaper will randomly select a valid image from the directory
- Avoids selecting the same image consecutively when possible

2. Deferred Preloading
- New `defer_preload` config option to reduce memory usage
- Wallpapers are loaded on-demand instead of all at startup
- Useful for systems with limited memory

Additional improvements:
- Better path handling with tilde expansion
- Updated README with new features
- Improved error handling

Feel free to leave feedback or lampoon as it's obviously not a small change, I saw https://github.com/hyprwm/hyprpaper/issues/194 and wanted to do something about it. 