### PR TITLE
Move systemd service install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,4 +142,4 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
 include(GNUInstallDirs)
 
 install(TARGETS hyprpaper)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprpaper.service DESTINATION "lib/systemd/user")


### PR DESCRIPTION
Install the service file to the proper location. This mirrors [hypridle](https://github.com/hyprwm/hypridle/blob/9d97c2288316f7ed474c0d8cd248516d8fb72037/CMakeLists.txt#L99-L100), [xdg-desktop-portal-hyprland](https://github.com/hyprwm/xdg-desktop-portal-hyprland/blob/e09dfe2726c8008f983e45a0aa1a3b7416aaeb8a/CMakeLists.txt#L147-L149) and [hyprpolkitagent](https://github.com/hyprwm/hyprpolkitagent/blob/3bef8bf8fcac95339d1e8cab3addbe83a7f99d57/CMakeLists.txt#L57-L58)