### PR TITLE
CMake: require wayland-protocols>=1.35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ pkg_check_modules(
   REQUIRED
   IMPORTED_TARGET
   wayland-client
-  wayland-protocols
+  wayland-protocols>=1.35
   cairo
   pango
   pangocairo


### PR DESCRIPTION
tablet-v2 was moved to stable in 1.35. Hyprpaper will fail to build if a earlier version is used.

Port change from https://github.com/hyprwm/hyprlock/pull/713

See https://github.com/hyprwm/hyprlock/issues/710 for context.

