### PR TITLE
Return empty string instead of throwing if unable to find default config

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -214,7 +214,7 @@ std::string CConfigManager::getMainConfigPath() {
     if (paths.first.has_value())
         return paths.first.value();
     else
-        throw std::runtime_error("Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr.");
+        return "";
 }
 
 // trim from both ends


### PR DESCRIPTION
hyprpaper will throw an exception if a user does not have a config file in any of the default directories. Interestingly I noticed it will run when using the `--config` flag even if that points to a file that does not exist:

```
[hyprpaper]$ ./build/hyprpaper
[LOG] Welcome to hyprpaper!
built from commit 79e0992927d8d8335e8c727461d35b0c73a855bf (    nix: update flake.lock (252))
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr.
Aborted (core dumped)
[hyprpaper]$ ls /tmp/foo
ls: cannot access '/tmp/foo': No such file or directory
[hyprpaper]$ ./build/hyprpaper --config /tmp/foo
[LOG] Welcome to hyprpaper!
built from commit 79e0992927d8d8335e8c727461d35b0c73a855bf (    nix: update flake.lock (252))
[LOG] Using config location /tmp/foo.
[WARN] Monitor DP-1 does not have a target! A wallpaper will not be created.
[WARN] Monitor HDMI-A-2 does not have a target! A wallpaper will not be created.
[LOG] hyprpaper socket started at /run/user/1000/hypr/9958d297641b5c84dcff93f9039d80a5ad37ab00_1749470930_702656021/.hyprpaper.sock (fd: 4)
```

I'd expect both cases to exhibit the same behavior. This PR will return an empty string in `getMainConfigPath()` so hyprpaper will run even if no config is found in the default directories. Closes #193 