### PR TITLE
Fix IPC segfault

### DIFF
--- a/src/ipc/Socket.cpp
+++ b/src/ipc/Socket.cpp
@@ -71,6 +71,9 @@ void CIPCSocket::initialize() {
                     m_bRequestReady = true;
 
                     g_pHyprpaper->tick(true);
+                    
+                    wl_display_roundtrip(g_pHyprpaper->m_sDisplay);
+                    
                     while (!m_bReplyReady) { // wait for Hyprpaper to finish processing the request
                         std::this_thread::sleep_for(std::chrono::milliseconds(1));
                     }


### PR DESCRIPTION
Hello, I said I would fix the IPC crash, and then forgot about it, but I am back! 

It still dies if you flood it hard enough ("Bus error"), but it no longer dies when you issue multiples of commands at once, as now the only way it dies is if you absolutely flood the living hell out of it, this fixes pretty much every legitimate use case that hyprpaper is actually meant to be used for, however it still struggles to play through bad apple at 30fps. and at around frame 2000 it will crash (very sad news)

Anyways, here is a before and after of the fix:


[before.webm](https://github.com/user-attachments/assets/9136b64c-e1b8-4611-a918-dffa3cb28ac4)



[after.webm](https://github.com/user-attachments/assets/5efa2534-ee97-4aec-b5e1-be8dc276b37f)
