### PR TITLE
Added "source=" capability to Hyprpaper .conf file

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -179,9 +179,9 @@ static Hyprlang::CParseResult handleReload(const char* C, const char* V) {
 static Hyprlang::CParseResult handleSource(const char* C, const char* V) {
     Hyprlang::CParseResult result;
 
-    const std::string path = g_pConfigManager->absolutePath(V);
+    const std::string      path = g_pConfigManager->absolutePath(V);
 
-    std::error_code ec;
+    std::error_code        ec;
     if (!std::filesystem::exists(path, ec)) {
         result.setError((ec ? ec.message() : "no such file").c_str());
         return result;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -176,6 +176,22 @@ static Hyprlang::CParseResult handleReload(const char* C, const char* V) {
     return Hyprlang::CParseResult{};
 }
 
+static Hyprlang::CParseResult handleSource(const char* C, const char* V) {
+    Hyprlang::CParseResult result;
+
+    const std::string path = g_pConfigManager->absolutePath(V);
+
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) {
+        result.setError((ec ? ec.message() : "no such file").c_str());
+        return result;
+    }
+
+    g_pConfigManager->config->parseFile(path.c_str());
+
+    return result;
+}
+
 CConfigManager::CConfigManager() {
     // Initialize the configuration
     // Read file from default location
@@ -195,6 +211,7 @@ CConfigManager::CConfigManager() {
     config->registerHandler(&handlePreload, "preload", {.allowFlags = false});
     config->registerHandler(&handleUnloadAll, "unloadAll", {.allowFlags = false});
     config->registerHandler(&handleReload, "reload", {.allowFlags = false});
+    config->registerHandler(&handleSource, "source", {.allowFlags = false});
 
     config->commence();
 }
@@ -226,4 +243,19 @@ std::string CConfigManager::trimPath(std::string path) {
     size_t pathStartIndex = path.find_first_not_of(" \t\r\n");
     size_t pathEndIndex   = path.find_last_not_of(" \t\r\n");
     return path.substr(pathStartIndex, pathEndIndex - pathStartIndex + 1);
+}
+
+std::string CConfigManager::absolutePath(const std::string& path) {
+    if (path.empty())
+        return "";
+
+    std::string result = path;
+
+    if (result[0] == '~') {
+        const char* home = getenv("HOME");
+        if (home)
+            result = std::string(home) + result.substr(1);
+    }
+
+    return std::filesystem::absolute(result).string();
 }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -13,7 +13,7 @@ class CConfigManager {
     std::deque<std::string>            m_dRequestedPreloads;
     std::string                        getMainConfigPath();
     std::string                        trimPath(std::string path);
-    std::string                 absolutePath(const std::string& path);
+    std::string                        absolutePath(const std::string& path);
 
     std::unique_ptr<Hyprlang::CConfig> config;
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -13,6 +13,7 @@ class CConfigManager {
     std::deque<std::string>            m_dRequestedPreloads;
     std::string                        getMainConfigPath();
     std::string                        trimPath(std::string path);
+    std::string                 absolutePath(const std::string& path);
 
     std::unique_ptr<Hyprlang::CConfig> config;
 


### PR DESCRIPTION
Hi, short answer: I'm creating a Wallpaper Manager in Rust (rs-paper name pending*) and as part of my logic for saving wallpaper "sets", I need to be able to quickly adjust per-display wallpapers without altering other monitors. I've come up with the solution of having .conf files for each display (auto-created by parsing hyprctl -j monitor results) and my app will take a selected wallpaper and update the specific .conf file to that wallpaper.

Using $variables, I can have a file be DP-1.conf and echo into it $DP-1 = path/to/image.png
Now my hyprpaper.conf can read:
preload = $DP-1
wallpaper = DP-1, $DP-1

I never adjust hyprpaper.conf outside of initial setup (which runs on start-up for simplicity) and my logic only targets per-monitor .conf files instead of re-writing the entire hypaper.conf

That said . . . source= was not implemented in hyprpaper like it is in Hyprland. This functionality is crucial for my app design & was very easy to implement (to be clear, I did rely on ChatGPT to assist with this). Hoping you guys could review the pull, feel free to rewrite/adjust the code however, just hoping to see this source= functionality in the main app.

Thank you!