### PR TITLE
Build error occurred; My prior commit broke the build commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,11 +107,12 @@ protocolnew("stable/xdg-shell" "xdg-shell" false)
 protocolnew("staging/cursor-shape" "cursor-shape-v1" false)
 protocolnew("stable/tablet" "tablet-v2" false)
 
+string(REPLACE "\"" "\\\"" GIT_COMMIT_MESSAGE_ESCAPED "${GIT_COMMIT_MESSAGE}")
 target_compile_definitions(hyprpaper
                            PRIVATE "-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
 target_compile_definitions(hyprpaper PRIVATE "-DGIT_BRANCH=\"${GIT_BRANCH}\"")
-target_compile_definitions(
-  hyprpaper PRIVATE "-DGIT_COMMIT_MESSAGE=\"${GIT_COMMIT_MESSAGE}\"")
+target_compile_definitions(hyprpaper
+                           PRIVATE "-DGIT_COMMIT_MESSAGE=\"${GIT_COMMIT_MESSAGE_ESCAPED}\"")
 target_compile_definitions(hyprpaper PRIVATE "-DGIT_DIRTY=\"${GIT_DIRTY}\"")
 
 target_link_libraries(hyprpaper rt)


### PR DESCRIPTION
**Using these build commands found on the main page of the repo:**
cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
cmake --build ./build --config Release --target hyprpaper -jnproc 2>/dev/null || getconf _NPROCESSORS_CONF

**I caused this error when building:**
/home/blake-sama/Developer/hyprpaper/src/main.cpp: In function ‘int main(int, char**, char**)’:
<command-line>: error: unable to find string literal operator ‘operator""source’ with ‘const char [19]’, ‘long unsigned int’ arguments
/home/blake-sama/Developer/hyprpaper/src/main.cpp:6:90: note: in expansion of macro ‘GIT_COMMIT_MESSAGE’
6 |     Debug::log(LOG, "Welcome to hyprpaper!\nbuilt from commit {} ({})", GIT_COMMIT_HASH, GIT_COMMIT_MESSAGE);
|                                                                                          ^~~~~~~~~~~~~~~~~~
make[3]: *** [CMakeFiles/hyprpaper.dir/build.make:205: CMakeFiles/hyprpaper.dir/src/main.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/Makefile2:87: CMakeFiles/hyprpaper.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:94: CMakeFiles/hyprpaper.dir/rule] Error 2
make: *** [Makefile:189: hyprpaper] Error 2

After ChatGPT'ing the error, when the build tried to compile, it detected a bad commit message. Well, that's because the most recent commit to the project was mine which had "source=" in the commit message. It failed to read the "" marks in my commit message correctly, breaking the compiler's ability to build hyprpaper.

I'm also not very great at explaining so here's ChatGPT expressing what this fix does:
"The fix I added ensures that any " characters in the commit message are escaped (\"), so that when the macro is expanded into C++, it stays within the bounds of a valid string literal. This prevents the preprocessor from misinterpreting the contents of commit messages."

tl;dr I'm sorry I broke the build with a bad commit message, lesson learned . . . don't use "" marks in commits.