### PR TITLE
feat: per-monitor wallpaper rotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ preload = /path/to/next_image.png
 # .. more preloads
 
 #set the default wallpaper(s) seen on initial workspace(s) --depending on the number of monitors used
+#
 wallpaper = monitor1,/path/to/image.png
 #if more than one monitor in use, can load a 2nd image
 wallpaper = monitor2,/path/to/next_image.png
@@ -98,6 +99,16 @@ You may add `contain:` or `tile:` before the file path in `wallpaper=` to set th
 ```
 wallpaper = monitor,contain:/path/to/image.jpg
 ```
+
+You can also specify an optional rotation (in degrees) for the wallpaper:
+
+```
+wallpaper = monitor,/path/to/image.jpg,90
+wallpaper = monitor,contain:/path/to/image.jpg,180
+wallpaper = monitor,tile:/path/to/image.jpg,270
+```
+
+Supported rotation values are 0, 90, 180, and 270 degrees. If no rotation is specified, it defaults to 0 (no rotation).
 
 A Wallpaper ***cannot*** be applied without preloading. The config is ***not*** reloaded dynamically.
 

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -571,7 +571,9 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
         PCAIRO,
         Vector2D(PWALLPAPERTARGET->m_vSize.x, PWALLPAPERTARGET->m_vSize.y),
         DIMENSIONS,
-        pMonitor->wallpaperRotation
+        pMonitor->wallpaperRotation,
+        CONTAIN,
+        TILE
     );
 
     if (TILE) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -71,11 +71,18 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
     g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].tile    = tile;
 
     // Set wallpaper rotation for the monitor
+    printf("DEBUG: Setting rotation %d for monitor '%s'\n", rotation, MONITOR.c_str());
+    bool rotationSet = false;
     for (auto& m : g_pHyprpaper->m_vMonitors) {
         if (m->name == MONITOR) {
             m->wallpaperRotation = rotation;
+            printf("DEBUG: Applied rotation %d to monitor %s\n", rotation, m->name.c_str());
+            rotationSet = true;
             break;
         }
+    }
+    if (!rotationSet && !MONITOR.empty()) {
+        printf("DEBUG: Monitor '%s' not found, rotation not applied\n", MONITOR.c_str());
     }
 
     if (MONITOR.empty()) {
@@ -85,6 +92,7 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
                 g_pHyprpaper->m_mMonitorActiveWallpapers[m->name]            = WALLPAPER;
                 g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].contain = contain;
                 g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].tile    = tile;
+                m->wallpaperRotation = rotation; // Apply rotation to wildcard monitors too
             }
         }
     } else {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -26,6 +26,9 @@ struct SMonitor {
     bool                                        wantsACK    = false;
     bool                                        initialized = false;
 
+    // Wallpaper rotation in degrees (0, 90, 180, 270)
+    int                                         wallpaperRotation = 0;
+
     std::vector<std::unique_ptr<CLayerSurface>> layerSurfaces;
     CLayerSurface*                              pCurrentLayerSurface = nullptr;
 

--- a/src/render/WallpaperTransform.hpp
+++ b/src/render/WallpaperTransform.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <cairo/cairo.h>
+#include <hyprutils/math/Vector2D.hpp>
+
+// Applies robust rotation, scaling, and centering for wallpaper rendering
+// Always fills the monitor (cover mode), centers image, and handles all rotations correctly
+inline void applyWallpaperTransform(cairo_t* cr, const Vector2D& imgSize, const Vector2D& monSize, int rotation) {
+    double imgW = imgSize.x;
+    double imgH = imgSize.y;
+    double monW = monSize.x;
+    double monH = monSize.y;
+    
+    // Normalize rotation
+    int rot = rotation % 360;
+    if (rot < 0) rot += 360;
+    
+    // For 90/270 degrees, the image dimensions are effectively swapped
+    bool isRotated90or270 = (rot == 90 || rot == 270);
+    double effectiveImgW = isRotated90or270 ? imgH : imgW;
+    double effectiveImgH = isRotated90or270 ? imgW : imgH;
+    
+    // Calculate scale to cover the monitor (larger scale wins)
+    double scaleX = monW / effectiveImgW;
+    double scaleY = monH / effectiveImgH;
+    double scale = std::max(scaleX, scaleY);
+    
+    // Debug output
+    printf("DEBUG Transform: rotation=%d, imgSize=[%.1f,%.1f], monSize=[%.1f,%.1f]\n", 
+           rot, imgW, imgH, monW, monH);
+    printf("DEBUG effective=[%.1f,%.1f], scales=[%.3f,%.3f], final_scale=%.3f\n", 
+           effectiveImgW, effectiveImgH, scaleX, scaleY, scale);
+    printf("DEBUG transforms: translate=[%.1f,%.1f], rotate=%.1f°, scale=%.3f, img_center=[%.1f,%.1f]\n",
+           monW/2.0, monH/2.0, (double)rot, scale, imgW/2.0, imgH/2.0);
+    
+    // Move to center of monitor
+    cairo_translate(cr, monW / 2.0, monH / 2.0);
+    
+    // Rotate around center
+    cairo_rotate(cr, rot * M_PI / 180.0);
+    
+    // Scale the image
+    cairo_scale(cr, scale, scale);
+    
+    // Move to center of image (so image center aligns with rotation center)
+    cairo_translate(cr, -imgW / 2.0, -imgH / 2.0);
+}

--- a/src/render/WallpaperTransform.hpp
+++ b/src/render/WallpaperTransform.hpp
@@ -2,9 +2,9 @@
 #include <cairo/cairo.h>
 #include <hyprutils/math/Vector2D.hpp>
 
-// Applies robust rotation, scaling, and centering for wallpaper rendering
-// Always fills the monitor (cover mode), centers image, and handles all rotations correctly
-inline void applyWallpaperTransform(cairo_t* cr, const Vector2D& imgSize, const Vector2D& monSize, int rotation) {
+// Applies rotation, scaling, and centering for wallpaper rendering
+// Supports cover, contain, and tile modes with proper rotation handling
+inline void applyWallpaperTransform(cairo_t* cr, const Vector2D& imgSize, const Vector2D& monSize, int rotation, bool contain = false, bool tile = false) {
     double imgW = imgSize.x;
     double imgH = imgSize.y;
     double monW = monSize.x;
@@ -19,10 +19,21 @@ inline void applyWallpaperTransform(cairo_t* cr, const Vector2D& imgSize, const 
     double effectiveImgW = isRotated90or270 ? imgH : imgW;
     double effectiveImgH = isRotated90or270 ? imgW : imgH;
     
-    // Calculate scale to cover the monitor (larger scale wins)
+    // Calculate scale based on mode
     double scaleX = monW / effectiveImgW;
     double scaleY = monH / effectiveImgH;
-    double scale = std::max(scaleX, scaleY);
+    double scale;
+    
+    if (contain) {
+        // Contain mode: fit entire image (smaller scale wins)
+        scale = std::min(scaleX, scaleY);
+    } else if (tile) {
+        // Tile mode: use 1:1 scale
+        scale = 1.0;
+    } else {
+        // Cover mode: fill monitor (larger scale wins)
+        scale = std::max(scaleX, scaleY);
+    }
     
     // Debug output
     printf("DEBUG Transform: rotation=%d, imgSize=[%.1f,%.1f], monSize=[%.1f,%.1f]\n", 


### PR DESCRIPTION
This PR adds support for rotating wallpapers per monitor with an optional rotation parameter in the wallpaper configuration. The feature integrates seamlessly with existing wallpaper modes (cover, contain, tile) and maintains full backward compatibility.

## Features Added
- **Per-monitor rotation**: Each monitor can have its wallpaper rotated independently (can also rotate the wallpaper on multiple monitors if applied)
- **90-degree increments**: Supports 0°, 90°, 180°, and 270° rotations.
- **Mode compatibility**: Works with all existing wallpaper modes (cover, contain, tile)
- **Robust validation**: Clear error messages for invalid rotation values
- **Backward compatibility**: Existing configs continue to work without changes

## Configuration Syntax
```ini
# Basic syntax with optional rotation
wallpaper = monitor_name,/path/to/image.jpg,90

# Works with all modes
wallpaper = HDMI-A-1,contain:/path/to/image.jpg,180
wallpaper = DP-1,tile:/path/to/image.jpg,270

# Backward compatible (rotation defaults to 0)
wallpaper = monitor,/path/to/image.jpg
```

## Tested with:

* All rotation angles (0°, 90°, 180°, 270°)
* All wallpaper modes (cover, contain, tile)
* Multiple monitor configurations
* Various image aspect ratios and resolutions
* Invalid input validation
* Backward compatibility with existing configs

## Use Cases

* Portrait monitor setups: Rotate landscape images for portrait displays
* Mixed orientations: Different rotations per monitor in multi-monitor setups
* Artistic layouts: Creative wallpaper arrangements
* Display matching: Align wallpapers with physical monitor rotation

## Breaking Changes
**None** - this is a fully backward-compatible addition.