### PR TITLE
feat: Added wallpaper rotation and mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ You may add `contain:` or `tile:` before the file path in `wallpaper=` to set th
 wallpaper = monitor,contain:/path/to/image.jpg
 ```
 
+If you want to rotate a wallpaper, add a ```, X``` at then end of the wallpaper rule, where ```X``` corresponds to a transform number, e.g.:
+
+```
+wallpaper = monitor,/path/to/image.jpg, 1
+```
+
+Transform list:
+
+```
+0 -> normal (no transforms)
+1 -> 90 degrees
+2 -> 180 degrees
+3 -> 270 degrees
+4 -> flipped
+5 -> flipped + 90 degrees
+6 -> flipped + 180 degrees
+7 -> flipped + 270 degrees
+```
+
 A Wallpaper ***cannot*** be applied without preloading. The config is ***not*** reloaded dynamically.
 
 ## Important note to the inner workings

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -581,13 +581,11 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
     if (ROTATION != 0) {
         cairo_translate(PCAIRO, DIMENSIONS.x / 2.0, DIMENSIONS.y / 2.0);
 
-        if (ROTATION % 4 != 0) {
+        if (ROTATION % 4 != 0)
             cairo_rotate(PCAIRO, (ROTATION % 4) * M_PI_2);
-        }
 
-        if (ROTATION >= 4) {
+        if (ROTATION >= 4)
             cairo_scale(PCAIRO, -1, 1);
-        }
 
         cairo_translate(PCAIRO, -DIMENSIONS.x / 2.0, -DIMENSIONS.y / 2.0);
     }

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -597,11 +597,10 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
         cairo_pattern_destroy(pattern);
     } else {
 
-        if (CONTAIN) {
+        if (CONTAIN)
             scale = std::min(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
-        } else {
+        else
             scale = std::max(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
-        }
 
         origin.x = (DIMENSIONS.x / scale - PWALLPAPERTARGET->m_vSize.x) / 2.0;
         origin.y = (DIMENSIONS.y / scale - PWALLPAPERTARGET->m_vSize.y) / 2.0;

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -529,6 +529,7 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
     const auto PWALLPAPERTARGET = m_mMonitorActiveWallpaperTargets[pMonitor];
     const auto CONTAIN          = m_mMonitorWallpaperRenderData[pMonitor->name].contain;
     const auto TILE             = m_mMonitorWallpaperRenderData[pMonitor->name].tile;
+    const auto ROTATION         = m_mMonitorWallpaperRenderData[pMonitor->name].rotation;
 
     if (!PWALLPAPERTARGET) {
         Debug::log(CRIT, "wallpaper target null in render??");
@@ -566,31 +567,57 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
 
     // get scale
     // we always do cover
-    double     scale;
+    double     scale = 1.0;
     Vector2D   origin;
+    
+    double imgW = PWALLPAPERTARGET->m_vSize.x;
+    double imgH = PWALLPAPERTARGET->m_vSize.y;
 
-    const bool LOWASPECTRATIO = pMonitor->size.x / pMonitor->size.y > PWALLPAPERTARGET->m_vSize.x / PWALLPAPERTARGET->m_vSize.y;
-    if ((CONTAIN && !LOWASPECTRATIO) || (!CONTAIN && LOWASPECTRATIO)) {
-        scale    = DIMENSIONS.x / PWALLPAPERTARGET->m_vSize.x;
-        origin.y = -(PWALLPAPERTARGET->m_vSize.y * scale - DIMENSIONS.y) / 2.0 / scale;
-    } else {
-        scale    = DIMENSIONS.y / PWALLPAPERTARGET->m_vSize.y;
-        origin.x = -(PWALLPAPERTARGET->m_vSize.x * scale - DIMENSIONS.x) / 2.0 / scale;
+    if ((ROTATION % 4 == 1) || (ROTATION % 4 == 3)) std::swap(imgW, imgH);
+
+    cairo_save(PCAIRO);
+
+    if (ROTATION != 0) {
+        cairo_translate(PCAIRO, DIMENSIONS.x / 2.0, DIMENSIONS.y / 2.0);
+
+        if (ROTATION % 4 != 0) {
+            cairo_rotate(PCAIRO, (ROTATION % 4) * M_PI_2);
+        }
+
+        if (ROTATION >= 4) {
+            cairo_scale(PCAIRO, -1, 1);
+        }
+
+        cairo_translate(PCAIRO, -DIMENSIONS.x / 2.0, -DIMENSIONS.y / 2.0);
     }
 
-    Debug::log(LOG, "Image data for {}: {} at [{:.2f}, {:.2f}], scale: {:.2f} (original image size: [{}, {}])", pMonitor->name, PWALLPAPERTARGET->m_szPath, origin.x, origin.y,
-               scale, (int)PWALLPAPERTARGET->m_vSize.x, (int)PWALLPAPERTARGET->m_vSize.y);
 
     if (TILE) {
         cairo_pattern_t* pattern = cairo_pattern_create_for_surface(PWALLPAPERTARGET->m_pCairoSurface->cairo());
         cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
         cairo_set_source(PCAIRO, pattern);
+        cairo_pattern_destroy(pattern);
     } else {
+        
+        if (CONTAIN){
+            scale = std::min(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
+        }else{
+            scale = std::max(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
+        }
+
+        origin.x = (DIMENSIONS.x / scale - PWALLPAPERTARGET->m_vSize.x) / 2.0;
+        origin.y = (DIMENSIONS.y / scale - PWALLPAPERTARGET->m_vSize.y) / 2.0;
+
         cairo_scale(PCAIRO, scale, scale);
         cairo_set_source_surface(PCAIRO, PWALLPAPERTARGET->m_pCairoSurface->cairo(), origin.x, origin.y);
     }
 
+    Debug::log(LOG, "Image data for {}: {} at [{:.2f}, {:.2f}], scale: {:.2f} (original image size: [{}, {}])", pMonitor->name, PWALLPAPERTARGET->m_szPath, origin.x, origin.y,
+               scale, (int)PWALLPAPERTARGET->m_vSize.x, (int)PWALLPAPERTARGET->m_vSize.y);
+
     cairo_paint(PCAIRO);
+
+    cairo_restore(PCAIRO);
 
     if (*PRENDERSPLASH && getenv("HYPRLAND_INSTANCE_SIGNATURE")) {
         auto SPLASH = execAndGet("hyprctl splash");
@@ -623,8 +650,6 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
 
         cairo_surface_flush(PWALLPAPERTARGET->m_pCairoSurface->cairo());
     }
-
-    cairo_restore(PCAIRO);
 
     if (pMonitor->pCurrentLayerSurface) {
         pMonitor->pCurrentLayerSurface->pSurface->sendAttach(PBUFFER->buffer.get(), 0, 0);

--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -567,13 +567,14 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
 
     // get scale
     // we always do cover
-    double     scale = 1.0;
-    Vector2D   origin;
-    
-    double imgW = PWALLPAPERTARGET->m_vSize.x;
-    double imgH = PWALLPAPERTARGET->m_vSize.y;
+    double   scale = 1.0;
+    Vector2D origin;
 
-    if ((ROTATION % 4 == 1) || (ROTATION % 4 == 3)) std::swap(imgW, imgH);
+    double   imgW = PWALLPAPERTARGET->m_vSize.x;
+    double   imgH = PWALLPAPERTARGET->m_vSize.y;
+
+    if ((ROTATION % 4 == 1) || (ROTATION % 4 == 3))
+        std::swap(imgW, imgH);
 
     cairo_save(PCAIRO);
 
@@ -591,17 +592,16 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
         cairo_translate(PCAIRO, -DIMENSIONS.x / 2.0, -DIMENSIONS.y / 2.0);
     }
 
-
     if (TILE) {
         cairo_pattern_t* pattern = cairo_pattern_create_for_surface(PWALLPAPERTARGET->m_pCairoSurface->cairo());
         cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
         cairo_set_source(PCAIRO, pattern);
         cairo_pattern_destroy(pattern);
     } else {
-        
-        if (CONTAIN){
+
+        if (CONTAIN) {
             scale = std::min(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
-        }else{
+        } else {
             scale = std::max(DIMENSIONS.x / imgW, DIMENSIONS.y / imgH);
         }
 

--- a/src/Hyprpaper.hpp
+++ b/src/Hyprpaper.hpp
@@ -19,6 +19,7 @@
 struct SWallpaperRenderData {
     bool contain = false;
     bool tile    = false;
+    uint32_t rotation = 0;
 };
 
 class CHyprpaper {

--- a/src/Hyprpaper.hpp
+++ b/src/Hyprpaper.hpp
@@ -17,8 +17,8 @@
 #include "protocols/wlr-layer-shell-unstable-v1.hpp"
 
 struct SWallpaperRenderData {
-    bool contain = false;
-    bool tile    = false;
+    bool     contain  = false;
+    bool     tile     = false;
     uint32_t rotation = 0;
 };
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -7,7 +7,7 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
     const std::string           COMMAND = C;
     const std::string           VALUE   = V;
     Hyprlang::CParseResult      result;
-    Hyprutils::String::CVarList args(VALUE, 3, ',', true);
+    Hyprutils::String::CVarList args(VALUE, 3, ',', false);
 
     if (args.size() < 2) {
         result.setError("wallpaper failed (syntax)");
@@ -160,7 +160,7 @@ static Hyprlang::CParseResult handleUnload(const char* C, const char* V) {
 static Hyprlang::CParseResult handleReload(const char* C, const char* V) {
     const std::string           COMMAND = C;
     const std::string           VALUE   = V;
-    Hyprutils::String::CVarList args(VALUE, 3, ',', true);
+    Hyprutils::String::CVarList args(VALUE, 3, ',', false);
 
     if (args.size() < 2) {
         Hyprlang::CParseResult result;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -13,15 +13,12 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
         return result;
     }
 
-    auto firstComma = VALUE.find_first_of(',');
+    auto firstComma  = VALUE.find_first_of(',');
     auto secondComma = VALUE.find_first_of(',', firstComma + 1);
 
     auto MONITOR = VALUE.substr(0, firstComma);
 
-    auto WALLPAPER = g_pConfigManager->trimPath(
-        VALUE.substr(firstComma + 1, 
-            (secondComma == std::string::npos ? std::string::npos : secondComma - firstComma - 1))
-    );
+    auto WALLPAPER = g_pConfigManager->trimPath(VALUE.substr(firstComma + 1, (secondComma == std::string::npos ? std::string::npos : secondComma - firstComma - 1)));
 
     bool contain = false;
 
@@ -70,18 +67,18 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
     }
 
     g_pHyprpaper->clearWallpaperFromMonitor(MONITOR);
-    g_pHyprpaper->m_mMonitorActiveWallpapers[MONITOR]            = WALLPAPER;
-    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].contain = contain;
-    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].tile    = tile;
+    g_pHyprpaper->m_mMonitorActiveWallpapers[MONITOR]             = WALLPAPER;
+    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].contain  = contain;
+    g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].tile     = tile;
     g_pHyprpaper->m_mMonitorWallpaperRenderData[MONITOR].rotation = rotation;
 
     if (MONITOR.empty()) {
         for (auto& m : g_pHyprpaper->m_vMonitors) {
             if (!m->hasATarget || m->wildcard) {
                 g_pHyprpaper->clearWallpaperFromMonitor(m->name);
-                g_pHyprpaper->m_mMonitorActiveWallpapers[m->name]            = WALLPAPER;
-                g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].contain = contain;
-                g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].tile    = tile;
+                g_pHyprpaper->m_mMonitorActiveWallpapers[m->name]             = WALLPAPER;
+                g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].contain  = contain;
+                g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].tile     = tile;
                 g_pHyprpaper->m_mMonitorWallpaperRenderData[m->name].rotation = rotation;
             }
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -42,11 +42,10 @@ static Hyprlang::CParseResult handleWallpaper(const char* C, const char* V) {
         WALLPAPER                        = std::string(ENVHOME) + WALLPAPER.substr(1);
     }
 
-    int rotation = 0;
+    uint32_t rotation = 0;
     if (secondComma != std::string::npos) {
-        std::string rotationStr = VALUE.substr(secondComma + 1);
         try {
-            rotation = std::stoi(rotationStr);
+            rotation = std::stoi(VALUE.substr(secondComma + 1));
             if (rotation < 0 || rotation > 7) {
                 result.setError("wallpaper failed (invalid rotation input: must be 0-7)");
                 return result;


### PR DESCRIPTION
This PR refactors the entire wallpaper rotation implementation from #276 

Following advice from @vaxerski, the rotation now aligns with [the monitor rotation in hyprland](https://wiki.hypr.land/Configuring/Monitors/#rotating).

I also copied and used the previous monitor rotation documentation from hyprland for this implementation.

This refactor is compatable with all existing configurations and no changes are required for current setups.