### PR TITLE
splash_font_family configuration option.

### DIFF
--- a/src/Hyprpaper.cpp
+++ b/src/Hyprpaper.cpp
@@ -599,7 +599,12 @@ void CHyprpaper::renderWallpaperForMonitor(SMonitor* pMonitor) {
 
         Debug::log(LOG, "Rendering splash: {}", SPLASH);
 
-        cairo_select_font_face(PCAIRO, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+        // Vaxry... why does your style include uppercase characters for stack variable names? - OgloTheNerd
+        const auto FONT = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_pConfigManager->config.get(), "splash_font_family");
+
+        Debug::log(LOG, "Splash font family: {}", *FONT);
+
+        cairo_select_font_face(PCAIRO, *FONT, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 
         const auto FONTSIZE = (int)(DIMENSIONS.y / 76.0 / scale);
         cairo_set_font_size(PCAIRO, FONTSIZE);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -205,6 +205,7 @@ CConfigManager::CConfigManager() {
     config->addConfigValue("splash", Hyprlang::INT{0L});
     config->addConfigValue("splash_offset", Hyprlang::FLOAT{2.F});
     config->addConfigValue("splash_color", Hyprlang::INT{0x55ffffff});
+    config->addConfigValue("splash_font_family", Hyprlang::STRING{"Sans"});
 
     config->registerHandler(&handleWallpaper, "wallpaper", {.allowFlags = false});
     config->registerHandler(&handleUnload, "unload", {.allowFlags = false});


### PR DESCRIPTION
Title says it all! :D

**BIG DISCLAIMER:** This did not work on my machine, but I tested a bunch of other things to make sure it wasn't an issue with Hyprpaper. It seems to be an issue with anything Hyprland-related that excepts custom font families. This includes the Hyprland configuration too.

^ Given the disclaimer above, I am hoping you guys test this code on your machines instead of throwing away this PR completely... I did spend time making this PR after all...