### PR TITLE
fix(config): support * as wildcard monitor for default wallpapers

### DIFF
--- a/src/config/WallpaperMatcher.cpp
+++ b/src/config/WallpaperMatcher.cpp
@@ -2,6 +2,14 @@
 
 #include <algorithm>
 
+// Check if a monitor string represents a wildcard (matches all monitors)
+// Empty string or "*" are both treated as wildcards.
+// "*" is preferred since hyprlang's special category system doesn't properly
+// return entries with empty string keys from listKeysForSpecialCategory().
+static bool isWildcard(const std::string& monitor) {
+    return monitor.empty() || monitor == "*";
+}
+
 void CWallpaperMatcher::addState(CConfigManager::SSetting&& s) {
     s.id = ++m_maxId;
 
@@ -57,13 +65,12 @@ std::optional<CWallpaperMatcher::rw<const CConfigManager::SSetting>> CWallpaperM
     for (const auto& s : m_settings) {
         if (s.monitor != monName)
             continue;
-
         return s;
     }
 
-    // match wildcard
+    // match wildcard (empty string or "*")
     for (const auto& s : m_settings) {
-        if (s.monitor.empty())
+        if (isWildcard(s.monitor))
             return s;
     }
 


### PR DESCRIPTION
Add isWildcard() helper to treat both empty string and "*" as wildcards when matching wallpaper settings to monitors.

This works around a limitation in hyprlang where listKeysForSpecialCategory() skips entries with empty string keys (due to isStatic check in retrieveKeysForCat), causing configs like:

    wallpaper {
        monitor =
        path = /path/to/image.png
    }

to be silently ignored. Users should now use "monitor = *" instead.