### PR TITLE
feat: Add ability to randomize sort order

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -200,7 +200,7 @@ std::vector<CConfigManager::SSetting> CConfigManager::getSettings() {
             }
         }
 
-        result.emplace_back(SSetting{.monitor = std::move(monitor), .fitMode = std::move(fitMode), .paths = std::move(resolvedPaths), .timeout = timeout, .order = order});
+        result.emplace_back(SSetting{.monitor = std::move(monitor), .fitMode = std::move(fitMode), .paths = std::move(resolvedPaths), .timeout = timeout});
     }
 
     return result;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -18,7 +18,6 @@ class CConfigManager {
         std::vector<std::string> paths;
         int                      timeout = 0;
         uint32_t                 id      = 0;
-        std::string              order;
     };
 
     constexpr static const uint32_t SETTING_INVALID = 0;


### PR DESCRIPTION
Add a 'wallpaper#order' config option with 'random' option which allows wallpaper directories to be shuffled randomly on hyprpaper launch. 'default' leaves existing behavior unchanged.

Caveat: I'm a javascript monkey by trade, so idk if this code is good or not, I had claude code spit it out for personal use and thought I'd see if there's any interest in this functionality more generally. It seems reasonable to me. Feel free to close if not wanted.