### PR TITLE
config: fix wallpaper:recursive does not exist

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -174,7 +174,8 @@ std::vector<CConfigManager::SSetting> CConfigManager::getSettings() {
 
     for (auto& key : keys) {
         std::string monitor, fitMode, path, order;
-        int         timeout, recursive;
+        int         timeout;
+        bool        recursive;
 
         try {
             monitor = std::any_cast<Hyprlang::STRING>(m_config.getSpecialConfigValue("wallpaper", "monitor", key.c_str()));
@@ -188,7 +189,7 @@ std::vector<CConfigManager::SSetting> CConfigManager::getSettings() {
             continue;
         }
 
-        const auto RESOLVE_PATH = getFullPath(path, recursive != 0);
+        const auto RESOLVE_PATH = getFullPath(path, recursive);
 
         if (!RESOLVE_PATH) {
             g_logger->log(LOG_ERR, "Failed to resolve path {}: {}", path, RESOLVE_PATH.error());
@@ -215,7 +216,14 @@ std::vector<CConfigManager::SSetting> CConfigManager::getSettings() {
             }
         }
 
-        result.emplace_back(SSetting{.monitor = std::move(monitor), .fitMode = std::move(fitMode), .paths = std::move(resolvedPaths), .order = std::move(order), .timeout = timeout});
+        result.emplace_back(SSetting{
+            .monitor = std::move(monitor),
+            .fitMode = std::move(fitMode),
+            .paths = std::move(resolvedPaths),
+            .order = std::move(order),
+            .timeout = timeout,
+            .recursive = recursive,
+        });
     }
 
     return result;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -16,9 +16,10 @@ class CConfigManager {
     struct SSetting {
         std::string              monitor, fitMode;
         std::vector<std::string> paths;
-        std::string              order   = "default";
-        int                      timeout = 0;
-        uint32_t                 id      = 0;
+        std::string              order     = "default";
+        int                      timeout   = 0;
+        uint32_t                 id        = 0;
+        bool                     recursive = false;
     };
 
     constexpr static const uint32_t SETTING_INVALID = 0;


### PR DESCRIPTION
Commit 51e497d forgot to include the new `recursive` option in `SSetting`. This was causing `hyprpaper` to fail [here](https://github.com/hyprwm/hyprlang/blob/7615ee388de18239a4ab1400946f3d0e498a8186/src/config.cpp#L453), when `recursive = true` was set. See [user report](https://old.reddit.com/r/hyprland/comments/1rz1dt9/hyprpaper_recursive_directories_setting_not/). Tested manually.
```
config option <wallpaper:recursive> does not exist
```

