### PR TITLE
fix: add null check for g_IPCSocket in onRepeatTimer

### DIFF
--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -140,7 +140,8 @@ void CWallpaperTarget::onRepeatTimer() {
     m_timer =
         m_backend->addTimer(std::chrono::milliseconds(std::chrono::seconds(m_imagesData->timeout)), [this](ASP<Hyprtoolkit::CTimer> self, void*) { onRepeatTimer(); }, nullptr);
 
-    IPC::g_IPCSocket->onWallpaperChanged(m_monitorName, m_lastPath);
+    if (IPC::g_IPCSocket)
+        IPC::g_IPCSocket->onWallpaperChanged(m_monitorName, m_lastPath);
 }
 
 void CUI::registerOutput(const SP<Hyprtoolkit::IOutput>& mon) {


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV crash when IPC is disabled (`ipc = 0` in config) and wallpaper rotation is active.

## Root Cause

`CWallpaperTarget::onRepeatTimer()` calls `IPC::g_IPCSocket->onWallpaperChanged()` without checking if `g_IPCSocket` is valid. When IPC is disabled or not initialized, `g_IPCSocket` is `nullptr`, causing a null pointer dereference.

## Crash Analysis (coredump)

```
Signal: SIGSEGV (11)
  #0  __gnu_cxx::__normal_iterator constructor (this->m_statusObjects, this=0x60)
  #1  std::vector::begin (this=0x60)
  #2  IPC::CSocket::onWallpaperChanged (this=0x0, mon="eDP-1", path="...")
  #3  CWallpaperTarget::onRepeatTimer
```

GDB confirmed `this=0x0` in `onWallpaperChanged` — `g_IPCSocket.get()` returned `nullptr`.

Since `CSocket::m_statusObjects` is at offset `0x60`, accessing `this->m_statusObjects` when `this=0x0` resolves to address `0x60`, which is unmapped → SIGSEGV.

## Fix

Add a null guard matching the pattern already used in `registerOutput()` and elsewhere:

```cpp
if (IPC::g_IPCSocket)
    IPC::g_IPCSocket->onWallpaperChanged(m_monitorName, m_lastPath);
```

## Note

IPC and wallpaper display are independent — wallpapers work fine without IPC. The crash only affects users who have wallpaper rotation configured while IPC is disabled.