### PR TITLE
feat: per-monitor independent random splash texts

### DIFF
--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -53,7 +53,7 @@ class CWallpaperTarget::CImagesData {
 
 CWallpaperTarget::CWallpaperTarget(SP<Hyprtoolkit::IBackend> backend, SP<Hyprtoolkit::IOutput> output, const std::vector<std::string>& path, Hyprtoolkit::eImageFitMode fitMode,
                                    const int timeout, const std::string& order) : m_monitorName(output->port()), m_backend(backend) {
-    static const auto SPLASH_REPLY = HyprlandSocket::getFromSocket("/splash");
+    const auto SPLASH_REPLY = HyprlandSocket::getFromSocket("/splash");
 
     static const auto PENABLESPLASH = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_config->hyprlang(), "splash");
     static const auto PSPLASHOFFSET = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_config->hyprlang(), "splash_offset");


### PR DESCRIPTION
## Summary

Previously, all monitors displayed the **exact same splash text** because `SPLASH_REPLY` was declared `static` in the `CWallpaperTarget` constructor — initialized once on first construction and reused for every subsequent monitor.

This single-line fix removes the `static` qualifier so that each `CWallpaperTarget` instance (one per monitor) independently calls `HyprlandSocket::getFromSocket("/splash")`, receiving a fresh random splash string from Hyprland.

## Changes

| File | Change |
|------|--------|
| `src/ui/UI.cpp` | `static const auto SPLASH_REPLY` → `const auto SPLASH_REPLY` |

## Verification

- Built successfully with `cmake --build build` (no errors, no warnings)
- Tested on a dual-monitor setup — each display now shows a different random splash text

## Notes

The other `static` locals in the same constructor (`PENABLESPLASH`, `PSPLASHOFFSET`, `PSPLASHALPHA`) remain static — those are config-level reads that should indeed be shared across monitors.