### PR TITLE
ui: add span fit_mode to split one image across outputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,12 @@ pkg_check_modules(
   hyprutils>=0.2.4
   wayland-client
   hyprtoolkit>=0.4.1
+  hyprgraphics
   hyprwire
   pixman-1
+  cairo
+  libpng
+  jsoncpp
   libdrm)
 
 file(GLOB_RECURSE SRCFILES "src/*.cpp")

--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ Hyprpaper is a simple and fast wallpaper utility for Hyprland with the ability t
 
 # Features
  - Per-output wallpapers
- - fill, tile, cover or contain modes
+ - fill, tile, cover, contain or span modes
  - fractional scaling support
  - IPC for fast wallpaper switches
+
+# Fit modes
+`fit_mode` controls how each wallpaper is placed on its output: `cover` (default), `contain`, `fill` (stretch), `tile`.
+
+`span` splits a single image across every output it is assigned to, so the picture appears continuous across the physical monitor arrangement. Outputs sharing the same `wallpaper {}` entry form one span group; the image is mapped onto the group's bounding box (in Hyprland's logical layout coordinates) and each output shows the sub-region its layout rectangle covers. Placement within that canvas is chosen with an optional sub-mode: `span` / `span:cover` (default), `span:contain`, `span:stretch`.
+
+Span requires Hyprland's IPC for the monitor layout; when it is unavailable (or an output's geometry can't be resolved) each output falls back to `cover`. A group of one output is equivalent to the matching plain mode.
 
 # Installation
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,10 +15,12 @@
   hyprwire,
   hyprwayland-scanner,
   libGL,
+  jsoncpp,
   libdatrie,
   libdrm,
   libjpeg,
   libjxl,
+  libpng,
   libselinux,
   libsepol,
   libthai,
@@ -76,6 +78,8 @@ stdenv.mkDerivation {
     libdrm
     libjpeg
     libjxl
+    libpng
+    jsoncpp
     libselinux
     libsepol
     libthai

--- a/src/helpers/MonitorLayout.cpp
+++ b/src/helpers/MonitorLayout.cpp
@@ -1,0 +1,63 @@
+#include "MonitorLayout.hpp"
+#include "Logger.hpp"
+#include "../ipc/HyprlandSocket.hpp"
+
+#include <memory>
+#include <json/json.h>
+
+std::optional<std::vector<MonitorLayout::SMonitor>> MonitorLayout::query() {
+    const auto REPLY = HyprlandSocket::getFromSocket("j/monitors");
+    if (!REPLY) {
+        g_logger->log(LOG_WARN, "span: couldn't query monitor layout: {}", REPLY.error());
+        return std::nullopt;
+    }
+
+    const std::string&                DATA = REPLY.value();
+    Json::CharReaderBuilder           builder;
+    Json::Value                       root;
+    std::string                       errs;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+
+    if (!reader->parse(DATA.c_str(), DATA.c_str() + DATA.size(), &root, &errs)) {
+        g_logger->log(LOG_ERR, "span: failed to parse monitor JSON: {}", errs);
+        return std::nullopt;
+    }
+
+    if (!root.isArray()) {
+        g_logger->log(LOG_ERR, "span: unexpected monitor JSON (not an array)");
+        return std::nullopt;
+    }
+
+    std::vector<SMonitor> result;
+    result.reserve(root.size());
+
+    for (const auto& m : root) {
+        if (m.get("disabled", false).asBool())
+            continue;
+
+        SMonitor mon;
+        mon.name      = m.get("name", "").asString();
+        mon.x         = m.get("x", 0).asDouble();
+        mon.y         = m.get("y", 0).asDouble();
+        mon.scale     = m.get("scale", 1.0).asDouble();
+        mon.transform = m.get("transform", 0).asInt();
+
+        if (mon.scale <= 0)
+            mon.scale = 1.0;
+
+        const double W = m.get("width", 0).asDouble();
+        const double H = m.get("height", 0).asDouble();
+
+        // wl_output transforms 90/270 (and their flipped variants) swap the logical footprint.
+        const bool ROTATED = (mon.transform % 2) != 0;
+        mon.w              = (ROTATED ? H : W) / mon.scale;
+        mon.h              = (ROTATED ? W : H) / mon.scale;
+
+        if (mon.name.empty() || mon.w <= 0 || mon.h <= 0)
+            continue;
+
+        result.emplace_back(std::move(mon));
+    }
+
+    return result;
+}

--- a/src/helpers/MonitorLayout.hpp
+++ b/src/helpers/MonitorLayout.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <optional>
+
+namespace MonitorLayout {
+    struct SMonitor {
+        std::string name;
+        double      x = 0, y = 0; // logical position
+        double      w = 0, h = 0; // logical size (transform-adjusted)
+        double      scale     = 1.0;
+        int         transform = 0;
+    };
+
+    // Queries the current monitor layout from Hyprland via IPC.
+    // Returns nullopt when not running under Hyprland or on any error.
+    std::optional<std::vector<SMonitor>> query();
+}

--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -5,16 +5,30 @@
 #include "../ipc/HyprlandSocket.hpp"
 #include "../ipc/IPC.hpp"
 #include "../config/WallpaperMatcher.hpp"
+#include "../helpers/MonitorLayout.hpp"
 
 #include <algorithm>
 #include <random>
 #include <hyprtoolkit/core/Output.hpp>
 
 #include <hyprutils/string/String.hpp>
+#include <filesystem>
+#include <cmath>
+#include <cstdlib>
+#include <cairo/cairo.h>
+#include <hyprgraphics/image/Image.hpp>
+#include <png.h>
+#include <cstdio>
+#include <vector>
 
 CUI::CUI() = default;
 
 CUI::~CUI() {
+    for (const auto& g : m_spanGroups) {
+        std::error_code ec;
+        for (const auto& [mon, path] : g->lastSlice)
+            std::filesystem::remove(path, ec);
+    }
     m_targets.clear();
 }
 
@@ -124,18 +138,29 @@ CWallpaperTarget::~CWallpaperTarget() {
         m_timer->cancel();
 }
 
+void CWallpaperTarget::stopSlideshow() {
+    if (m_timer && !m_timer->passed())
+        m_timer->cancel();
+    m_timer.reset();
+    m_imagesData.reset();
+}
+
+void CWallpaperTarget::setImage(const std::string& path, Hyprtoolkit::eImageFitMode fitMode, bool sync) {
+    m_lastPath = path;
+
+    m_image->rebuild()
+        ->path(std::string{path})
+        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+        ->sync(sync)
+        ->fitMode(fitMode)
+        ->commence();
+}
+
 void CWallpaperTarget::onRepeatTimer() {
 
     ASSERT(m_imagesData);
 
-    m_lastPath = m_imagesData->nextImage();
-
-    m_image->rebuild()
-        ->path(std::string{m_lastPath})
-        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
-        ->sync(true)
-        ->fitMode(m_imagesData->fitMode)
-        ->commence();
+    setImage(m_imagesData->nextImage(), m_imagesData->fitMode);
 
     m_timer =
         m_backend->addTimer(std::chrono::milliseconds(std::chrono::seconds(m_imagesData->timeout)), [this](ASP<Hyprtoolkit::CTimer> self, void*) { onRepeatTimer(); }, nullptr);
@@ -153,6 +178,13 @@ void CUI::registerOutput(const SP<Hyprtoolkit::IOutput>& mon) {
         if (IPC::g_IPCSocket)
             IPC::g_IPCSocket->onRemovedDisplay(m->port());
         std::erase_if(m_targets, [&m](const auto& e) { return e->m_monitorName == m->port(); });
+        std::vector<uint32_t> ids;
+        ids.reserve(m_spanGroups.size());
+        for (const auto& g : m_spanGroups)
+            ids.emplace_back(g->id);
+        for (const auto id : ids)
+            rebuildSpanGroup(id);
+        pruneSpanGroups();
     });
 }
 
@@ -211,6 +243,146 @@ static Hyprtoolkit::eImageFitMode toFitMode(const std::string_view& sv) {
     return Hyprtoolkit::IMAGE_FIT_MODE_COVER;
 }
 
+namespace {
+    bool isSpanFitMode(const std::string_view& sv) {
+        return sv == "span" || sv.starts_with("span:");
+    }
+
+    std::string spanSubMode(const std::string_view& sv) {
+        const auto POS = sv.find(':');
+        if (POS == std::string_view::npos)
+            return "cover";
+        const auto SUB = sv.substr(POS + 1);
+        if (SUB == "contain" || SUB == "stretch" || SUB == "cover")
+            return std::string{SUB};
+        return "cover";
+    }
+
+    Hyprtoolkit::eImageFitMode subModeToFit(const std::string& m) {
+        if (m == "contain")
+            return Hyprtoolkit::IMAGE_FIT_MODE_CONTAIN;
+        if (m == "stretch")
+            return Hyprtoolkit::IMAGE_FIT_MODE_STRETCH;
+        return Hyprtoolkit::IMAGE_FIT_MODE_COVER;
+    }
+
+    std::string spanDir() {
+        const char*           rt   = getenv("XDG_RUNTIME_DIR");
+        std::filesystem::path base = (rt && *rt) ? std::filesystem::path(rt) / "hyprpaper" : std::filesystem::temp_directory_path() / "hyprpaper";
+        std::error_code       ec;
+        std::filesystem::create_directories(base, ec);
+        return base.string();
+    }
+
+    // Fast lossless PNG writer: cairo's write_to_png uses zlib level 6 and costs
+    // seconds on monitor-sized images. libpng at level 1 + SUB filter is ~10x faster.
+    bool writePNGFast(cairo_surface_t* dst, const std::string& outPath) {
+        cairo_surface_flush(dst);
+        const int      w      = cairo_image_surface_get_width(dst);
+        const int      h      = cairo_image_surface_get_height(dst);
+        const int      stride = cairo_image_surface_get_stride(dst);
+        const uint8_t* data   = cairo_image_surface_get_data(dst);
+        if (!data || w <= 0 || h <= 0)
+            return false;
+
+        FILE* f = fopen(outPath.c_str(), "wb");
+        if (!f)
+            return false;
+
+        png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+        if (!png) {
+            fclose(f);
+            return false;
+        }
+        png_infop info = png_create_info_struct(png);
+        if (!info) {
+            png_destroy_write_struct(&png, nullptr);
+            fclose(f);
+            return false;
+        }
+
+        // The row buffer is a raw allocation made BEFORE setjmp and never reassigned, so it
+        // stays valid (and freeable) if libpng longjmps here on a write error. Nothing with a
+        // non-trivial destructor may be live across the jump, so no std::vector.
+        uint8_t* row = sc<uint8_t*>(malloc(sc<size_t>(w) * 3));
+        if (!row) {
+            png_destroy_write_struct(&png, &info);
+            fclose(f);
+            return false;
+        }
+
+        if (setjmp(png_jmpbuf(png))) {
+            free(row);
+            png_destroy_write_struct(&png, &info);
+            fclose(f);
+            return false;
+        }
+
+        png_init_io(png, f);
+        png_set_compression_level(png, 1);
+        png_set_filter(png, 0, PNG_FILTER_SUB);
+        png_set_IHDR(png, info, w, h, 8, PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+        png_write_info(png, info);
+
+        // cairo ARGB32 is premultiplied BGRA in memory; slices are opaque, so BGRA->RGB is exact.
+        for (int y = 0; y < h; ++y) {
+            const uint8_t* srow = data + sc<size_t>(y) * stride;
+            for (int x = 0; x < w; ++x) {
+                row[x * 3 + 0] = srow[x * 4 + 2];
+                row[x * 3 + 1] = srow[x * 4 + 1];
+                row[x * 3 + 2] = srow[x * 4 + 0];
+            }
+            png_write_row(png, row);
+        }
+        png_write_end(png, info);
+
+        free(row);
+        png_destroy_write_struct(&png, &info);
+        fclose(f);
+        return true;
+    }
+
+    // Renders monitor `mon`'s portion of the source onto a PNG at `outPath`.
+    // The source is mapped onto the whole virtual canvas per `subMode`; each monitor
+    // then samples the sub-rectangle that its layout rect covers.
+    bool renderSlice(cairo_surface_t* src, double Iw, double Ih, double canvasX0, double canvasY0, double canvasW, double canvasH, const MonitorLayout::SMonitor& mon,
+                     const std::string& subMode, const std::string& outPath) {
+        const int devW = std::lround(mon.w * mon.scale);
+        const int devH = std::lround(mon.h * mon.scale);
+        if (devW <= 0 || devH <= 0)
+            return false;
+
+        double ox = 0, oy = 0, fx = 0, fy = 0;
+        if (subMode == "stretch") {
+            fx = canvasW / Iw;
+            fy = canvasH / Ih;
+        } else {
+            const double f = (subMode == "contain") ? std::min(canvasW / Iw, canvasH / Ih) : std::max(canvasW / Iw, canvasH / Ih);
+            fx = fy = f;
+            ox      = (canvasW - Iw * f) / 2.0;
+            oy      = (canvasH - Ih * f) / 2.0;
+        }
+
+        cairo_surface_t* dst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, devW, devH);
+        cairo_t*         cr  = cairo_create(dst);
+
+        // device = (canvas - monitorOrigin) * scale; user space becomes canvas-logical coords
+        cairo_scale(cr, mon.scale, mon.scale);
+        cairo_translate(cr, -(mon.x - canvasX0), -(mon.y - canvasY0));
+        // then place the source image within the canvas
+        cairo_translate(cr, ox, oy);
+        cairo_scale(cr, fx, fy);
+        cairo_set_source_surface(cr, src, 0, 0);
+        cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_GOOD);
+        cairo_paint(cr);
+
+        cairo_destroy(cr);
+        const bool ok = writePNGFast(dst, outPath);
+        cairo_surface_destroy(dst);
+        return ok;
+    }
+}
+
 void CUI::targetChanged(const std::string_view& monName) {
     const auto               MONITORS = m_backend->getOutputs();
     SP<Hyprtoolkit::IOutput> monitor;
@@ -233,16 +405,260 @@ void CUI::targetChanged(const std::string_view& monName) {
 void CUI::targetChanged(const SP<Hyprtoolkit::IOutput>& mon) {
     const auto TARGET = g_matcher->getSetting(mon->port(), pruneDesc(mon->desc()));
 
+    // NOTE: the span path deliberately does NOT erase the target here — rebuildSpanGroup
+    // updates members in place, so erasing would defeat its signature guard and force a
+    // full re-render on every startup/config event.
+
     if (!TARGET) {
         g_logger->log(LOG_DEBUG, "Monitor {} has no target: no wp will be created", mon->port());
+        std::erase_if(m_targets, [&mon](const auto& e) { return e->m_monitorName == mon->port(); });
+        rebuildOtherSpanGroups(CConfigManager::SETTING_INVALID);
+        return;
+    }
+
+    const auto& S = TARGET->get();
+
+    if (isSpanFitMode(S.fitMode)) {
+        if (!spanGroupFor(S.id)) {
+            auto grp     = makeUnique<SSpanGroup>();
+            grp->id      = S.id;
+            grp->subMode = spanSubMode(S.fitMode);
+            grp->paths   = S.paths;
+            grp->order   = S.order;
+            grp->timeout = S.timeout > 0 ? S.timeout : 30;
+            m_spanGroups.emplace_back(std::move(grp));
+
+            if (S.paths.size() > 1)
+                m_spanGroups.back()->timer = m_backend->addTimer(std::chrono::milliseconds(std::chrono::seconds(m_spanGroups.back()->timeout)),
+                                                                 [this, id = S.id](ASP<Hyprtoolkit::CTimer> self, void*) { onSpanTimer(id); }, nullptr);
+        }
+        rebuildSpanGroup(S.id);
+        pruneSpanGroups();
         return;
     }
 
     std::erase_if(m_targets, [&mon](const auto& e) { return e->m_monitorName == mon->port(); });
-
-    m_targets.emplace_back(makeShared<CWallpaperTarget>(m_backend, mon, TARGET->get().paths, toFitMode(TARGET->get().fitMode), TARGET->get().timeout, TARGET->get().order));
+    m_targets.emplace_back(makeShared<CWallpaperTarget>(m_backend, mon, S.paths, toFitMode(S.fitMode), S.timeout, S.order));
+    rebuildOtherSpanGroups(CConfigManager::SETTING_INVALID);
 }
 
 const std::vector<SP<CWallpaperTarget>>& CUI::targets() {
     return m_targets;
+}
+
+CUI::SSpanGroup* CUI::spanGroupFor(uint32_t id) {
+    for (auto& g : m_spanGroups) {
+        if (g->id == id)
+            return g.get();
+    }
+    return nullptr;
+}
+
+void CUI::removeSpanGroup(uint32_t id) {
+    for (auto& g : m_spanGroups) {
+        if (g->id != id)
+            continue;
+        if (g->timer && !g->timer->passed())
+            g->timer->cancel();
+        std::error_code ec;
+        for (const auto& [mon, path] : g->lastSlice)
+            std::filesystem::remove(path, ec);
+    }
+    std::erase_if(m_spanGroups, [id](const auto& g) { return g->id == id; });
+}
+
+void CUI::pruneSpanGroups() {
+    const auto            OUTPUTS = m_backend->getOutputs();
+    std::vector<uint32_t> dead;
+    for (auto& g : m_spanGroups) {
+        const bool HAS_MEMBER = std::ranges::any_of(OUTPUTS, [&](const auto& o) {
+            const auto st = g_matcher->getSetting(o->port(), pruneDesc(o->desc()));
+            return st && st->get().id == g->id;
+        });
+        if (!HAS_MEMBER)
+            dead.emplace_back(g->id);
+    }
+    for (const auto id : dead)
+        removeSpanGroup(id);
+}
+
+// Rebuilds every span group except `except` (canvas may have changed for survivors).
+void CUI::rebuildOtherSpanGroups(uint32_t except) {
+    std::vector<uint32_t> ids;
+    ids.reserve(m_spanGroups.size());
+    for (const auto& g : m_spanGroups) {
+        if (g->id != except)
+            ids.emplace_back(g->id);
+    }
+    for (const auto id : ids)
+        rebuildSpanGroup(id);
+    pruneSpanGroups();
+}
+
+void CUI::onSpanTimer(uint32_t id) {
+    auto* g = spanGroupFor(id);
+    if (!g || g->paths.empty())
+        return;
+
+    // advance to the next base image (mirrors CImagesData::nextImage)
+    if (g->order == "random-shuffle" && g->current + 1 >= g->paths.size()) {
+        std::random_device rd;
+        std::mt19937       gen(rd());
+        std::shuffle(g->paths.begin(), g->paths.end(), gen);
+        g->current = 0;
+    } else
+        g->current = (g->current + 1) % g->paths.size();
+
+    rebuildSpanGroup(id);
+
+    g = spanGroupFor(id);
+    if (!g)
+        return;
+    g->timer = m_backend->addTimer(std::chrono::milliseconds(std::chrono::seconds(g->timeout)), [this, id](ASP<Hyprtoolkit::CTimer> self, void*) { onSpanTimer(id); }, nullptr);
+}
+
+void CUI::rebuildSpanGroup(uint32_t id) {
+    if (!spanGroupFor(id))
+        return;
+
+    const auto OUTPUTS = m_backend->getOutputs();
+
+    // members = outputs currently resolving to this span setting
+    std::vector<SP<Hyprtoolkit::IOutput>> members;
+    for (const auto& o : OUTPUTS) {
+        const auto st = g_matcher->getSetting(o->port(), pruneDesc(o->desc()));
+        if (st && st->get().id == id)
+            members.emplace_back(o);
+    }
+
+    if (members.empty()) {
+        removeSpanGroup(id);
+        return;
+    }
+
+    auto* g = spanGroupFor(id);
+    if (g->paths.empty())
+        return;
+    const std::string base = g->paths[g->current % g->paths.size()];
+
+    // skip if nothing that affects the output changed since the last render
+    std::string sig = g->subMode + "|" + base;
+    {
+        std::vector<std::string> names;
+        names.reserve(members.size());
+        for (const auto& o : members)
+            names.emplace_back(o->port());
+        std::ranges::sort(names);
+        for (const auto& n : names)
+            sig += "|" + n;
+    }
+    // Skip only when nothing changed AND every member still has a live target.
+    // Defensive: a target can be dropped out-of-band (e.g. the output-removed
+    // listener), and such a member must be recreated rather than skipped.
+    const bool ALL_PRESENT = std::ranges::all_of(members, [this](const auto& o) {
+        return std::ranges::any_of(m_targets, [&o](const auto& e) { return e->m_monitorName == o->port(); });
+    });
+    if (sig == g->lastSig && ALL_PRESENT)
+        return;
+    g->lastSig = sig;
+
+    // ensure/update a per-monitor window with the given image + fit mode.
+    // updates load async so a slow decode never blocks the event loop.
+    auto applyToMonitor = [this](const SP<Hyprtoolkit::IOutput>& o, const std::string& imgPath, Hyprtoolkit::eImageFitMode fit) {
+        for (auto& e : m_targets) {
+            if (e->m_monitorName == o->port()) {
+                e->stopSlideshow(); // in case this target was previously a standalone slideshow
+                e->setImage(imgPath, fit, false);
+                return;
+            }
+        }
+        m_targets.emplace_back(makeShared<CWallpaperTarget>(m_backend, o, std::vector<std::string>{imgPath}, fit, 0, "default"));
+    };
+
+    auto coverFallback = [&]() {
+        for (const auto& o : members) {
+            applyToMonitor(o, base, Hyprtoolkit::IMAGE_FIT_MODE_COVER);
+            if (IPC::g_IPCSocket)
+                IPC::g_IPCSocket->onWallpaperChanged(o->port(), base);
+        }
+    };
+
+    const auto LAYOUT = MonitorLayout::query();
+    if (!LAYOUT) {
+        g_logger->log(LOG_WARN, "span: no monitor layout available, falling back to cover");
+        coverFallback();
+        return;
+    }
+
+    // gather geometry for every member
+    std::vector<MonitorLayout::SMonitor> geo;
+    geo.reserve(members.size());
+    for (const auto& o : members) {
+        const auto it = std::ranges::find_if(*LAYOUT, [&](const auto& mo) { return mo.name == o->port(); });
+        if (it == LAYOUT->end()) {
+            g_logger->log(LOG_WARN, "span: no geometry for output {}, falling back to cover", o->port());
+            coverFallback();
+            return;
+        }
+        geo.emplace_back(*it);
+    }
+
+    // single monitor: span degenerates to the matching simple fit mode
+    if (members.size() == 1) {
+        applyToMonitor(members.front(), base, subModeToFit(g->subMode));
+        if (IPC::g_IPCSocket)
+            IPC::g_IPCSocket->onWallpaperChanged(members.front()->port(), base);
+        return;
+    }
+
+    // decode the source once for the whole group
+    Hyprgraphics::CImage img(base);
+    if (!img.success() || !img.cairoSurface()) {
+        g_logger->log(LOG_ERR, "span: failed to decode {}: {}", base, img.getError());
+        coverFallback();
+        return;
+    }
+    cairo_surface_t* src   = img.cairoSurface()->cairo();
+    const auto       ISIZE = img.cairoSurface()->size();
+    const double     IW = ISIZE.x, IH = ISIZE.y;
+    if (IW <= 0 || IH <= 0) {
+        coverFallback();
+        return;
+    }
+
+    // virtual canvas = bounding box of member monitors (logical coords)
+    double x0 = geo.front().x, y0 = geo.front().y, x1 = geo.front().x + geo.front().w, y1 = geo.front().y + geo.front().h;
+    for (const auto& mo : geo) {
+        x0 = std::min(x0, mo.x);
+        y0 = std::min(y0, mo.y);
+        x1 = std::max(x1, mo.x + mo.w);
+        y1 = std::max(y1, mo.y + mo.h);
+    }
+    const double CW = x1 - x0, CH = y1 - y0;
+
+    const std::string DIR = spanDir();
+    const uint64_t    seq = ++g->seq;
+    for (size_t i = 0; i < members.size(); ++i) {
+        const auto&       o       = members[i];
+        const auto&       mo      = geo[i];
+        const std::string outPath = DIR + "/span-" + std::to_string(id) + "-" + o->port() + "-" + std::to_string(seq) + ".png";
+
+        if (!renderSlice(src, IW, IH, x0, y0, CW, CH, mo, g->subMode, outPath)) {
+            g_logger->log(LOG_ERR, "span: failed to render slice for {}", o->port());
+            applyToMonitor(o, base, Hyprtoolkit::IMAGE_FIT_MODE_COVER);
+            continue;
+        }
+
+        applyToMonitor(o, outPath, Hyprtoolkit::IMAGE_FIT_MODE_STRETCH);
+
+        const auto prev = g->lastSlice.find(o->port());
+        if (prev != g->lastSlice.end() && prev->second != outPath) {
+            std::error_code ec;
+            std::filesystem::remove(prev->second, ec);
+        }
+        g->lastSlice[o->port()] = outPath;
+
+        if (IPC::g_IPCSocket)
+            IPC::g_IPCSocket->onWallpaperChanged(o->port(), base);
+    }
 }

--- a/src/ui/UI.hpp
+++ b/src/ui/UI.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_map>
 
 #include <hyprtoolkit/core/Backend.hpp>
 #include <hyprtoolkit/core/Timer.hpp>
@@ -25,6 +26,12 @@ class CWallpaperTarget {
     CWallpaperTarget(CWallpaperTarget&&)      = delete;
 
     std::string m_monitorName, m_lastPath;
+
+    // Rebuilds the shown image in place (used by slideshow + span groups).
+    void        setImage(const std::string& path, Hyprtoolkit::eImageFitMode fitMode, bool sync = true);
+
+    // Detaches any standalone slideshow timer (used when a target is adopted into a span group).
+    void        stopSlideshow();
 
   private:
     void onRepeatTimer();
@@ -55,9 +62,31 @@ class CUI {
     void                              targetChanged(const std::string_view& monName);
     void                              registerOutput(const SP<Hyprtoolkit::IOutput>& mon);
 
+    // span support
+    struct SSpanGroup {
+        uint32_t                                     id      = 0;
+        std::string                                  subMode = "cover"; // cover | contain | stretch
+        std::vector<std::string>                     paths;
+        std::string                                  order   = "default";
+        int                                          timeout = 30;
+        size_t                                       current = 0;
+        uint64_t                                     seq     = 0;
+        ASP<Hyprtoolkit::CTimer>                     timer;
+        std::unordered_map<std::string, std::string> lastSlice; // monitor -> last slice file
+        std::string                                  lastSig;   // render signature; skip redundant rebuilds
+    };
+
+    CUI::SSpanGroup*                  spanGroupFor(uint32_t id);
+    void                              rebuildSpanGroup(uint32_t id);
+    void                              removeSpanGroup(uint32_t id);
+    void                              pruneSpanGroups();
+    void                              rebuildOtherSpanGroups(uint32_t except);
+    void                              onSpanTimer(uint32_t id);
+
     SP<Hyprtoolkit::IBackend>         m_backend;
 
     std::vector<SP<CWallpaperTarget>> m_targets;
+    std::vector<UP<SSpanGroup>>       m_spanGroups;
 
     struct {
         Hyprutils::Signal::CHyprSignalListener targetChanged;


### PR DESCRIPTION
## Summary

Adds `fit_mode = span`, which splits a single wallpaper across every output it
is assigned to so the image is continuous across the physical monitor
arrangement, instead of repeating the whole image on each output (which is what
`cover`/`contain`/`fill`/`tile` do today).

Optional sub-modes control how the source is fit onto the combined canvas:
- `span` / `span:cover` (default) — fill the canvas, crop overflow
- `span:contain` — fit the whole image, letterbox
- `span:stretch` — stretch to the canvas aspect

## Example

```
wallpaper {
    monitor =
    path = /path/to/ultrawide.png
    fit_mode = span
}
```

## How it works

- Outputs resolving to the same `wallpaper` entry form a span group.
- The monitor layout is queried from Hyprland over IPC (`j/monitors`).
- The image is mapped onto the group's bounding box in **logical** layout
  coordinates (so mixed-DPI monitors stay continuous in physical size), and
  each output is handed the sub-rectangle its layout rect covers.
- Slices are rendered with cairo and cached as PNGs under `$XDG_RUNTIME_DIR`.
- A group of one output is equivalent to the matching plain fit mode.

## Fallback

If the layout can't be read (not under Hyprland, or an output's geometry can't
be resolved), each output falls back to `cover` with a warning.

## Dependencies

Adds `cairo`, `hyprgraphics`, `libpng`, and `jsoncpp` (CMake + nix).
`cairo`/`hyprgraphics` were already transitively present via hyprtoolkit;
`libpng` and `jsoncpp` are new.

## Testing

- Verified on a 3-monitor layout (mixed transforms and resolutions): slices are
  geometrically contiguous across seams, and mixed-height/DPI monitors sample
  the correct region.
- Verified `span:cover` cropping, the single-output degenerate case, and the
  no-Hyprland cover fallback.

## Known limitations

- An **in-place** monitor geometry change (resolution/scale/reposition without
  an unplug) doesn't re-slice until the wallpaper is re-set — hyprtoolkit
  exposes no "output changed" signal. Hotplug (add/remove) is handled.
- Rotated outputs work (logical dimensions handled); flipped transforms (4–7)
  are untested.
- `span` is config-file only; the IPC/`hyprctl` fit-mode enum isn't extended
  (that would be a protocol change).